### PR TITLE
fix(groupNames): looks like those names cannot have spaces

### DIFF
--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -7,7 +7,7 @@
     "macrosInSelect": false,
     "selectItems": [
       {
-        "displayValue": "Init",
+        "displayValue": "Initialization",
         "value": "init"
       },
       {
@@ -46,7 +46,7 @@
   },
   {
     "displayName": "Method Details",
-    "name": "Method Labels Group",
+    "name": "MethodLabelsGroup",
     "groupStyle": "NO_ZIPPY",
     "type": "GROUP",
     "subParams": [
@@ -168,7 +168,7 @@
         "paramValue": "init"
       }
     ],
-    "name": "Init Options",
+    "name": "InitOptions",
     "displayName": "Init Options",
     "groupStyle": "NO_ZIPPY",
     "type": "GROUP",
@@ -198,7 +198,7 @@
       }
     ],
     "displayName": "Advanced init options",
-    "name": "Advanced init options",
+    "name": "AdvancedInitOptions",
     "groupStyle": "ZIPPY_CLOSED",
     "type": "GROUP",
     "subParams": [
@@ -283,7 +283,7 @@
         "paramValue": "init"
       }
     ],
-    "name": "Event options",
+    "name": "EventOptions",
     "displayName": "Event Options",
     "groupStyle": "ZIPPY_OPEN",
     "type": "GROUP",

--- a/src/template.js
+++ b/src/template.js
@@ -6,7 +6,7 @@ const setInWindow = require('setInWindow');
 const copyFromWindow = require('copyFromWindow');
 const makeInteger = require('makeInteger');
 
-const TEMPLATE_VERSION = '1.0.1';
+const TEMPLATE_VERSION = '1.0.2';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
 const aa = createArgumentsQueue('aa', 'aa.queue');
 

--- a/template.tpl
+++ b/template.tpl
@@ -34,7 +34,7 @@ ___TEMPLATE_PARAMETERS___
     "macrosInSelect": false,
     "selectItems": [
       {
-        "displayValue": "Init",
+        "displayValue": "Initialization",
         "value": "init"
       },
       {
@@ -73,7 +73,7 @@ ___TEMPLATE_PARAMETERS___
   },
   {
     "displayName": "Method Details",
-    "name": "Method Labels Group",
+    "name": "MethodLabelsGroup",
     "groupStyle": "NO_ZIPPY",
     "type": "GROUP",
     "subParams": [
@@ -195,7 +195,7 @@ ___TEMPLATE_PARAMETERS___
         "paramValue": "init"
       }
     ],
-    "name": "Init Options",
+    "name": "InitOptions",
     "displayName": "Init Options",
     "groupStyle": "NO_ZIPPY",
     "type": "GROUP",
@@ -225,7 +225,7 @@ ___TEMPLATE_PARAMETERS___
       }
     ],
     "displayName": "Advanced init options",
-    "name": "Advanced init options",
+    "name": "AdvancedInitOptions",
     "groupStyle": "ZIPPY_CLOSED",
     "type": "GROUP",
     "subParams": [
@@ -310,7 +310,7 @@ ___TEMPLATE_PARAMETERS___
         "paramValue": "init"
       }
     ],
-    "name": "Event options",
+    "name": "EventOptions",
     "displayName": "Event Options",
     "groupStyle": "ZIPPY_OPEN",
     "type": "GROUP",
@@ -655,7 +655,7 @@ const setInWindow = require('setInWindow');
 const copyFromWindow = require('copyFromWindow');
 const makeInteger = require('makeInteger');
 
-const TEMPLATE_VERSION = '1.0.1';
+const TEMPLATE_VERSION = '1.0.2';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
 const aa = createArgumentsQueue('aa', 'aa.queue');
 


### PR DESCRIPTION
As incredible as it sounds, any group with a space within their name won't be displayed...

# Before:
![image](https://user-images.githubusercontent.com/29529/113320537-e4aa6a00-9312-11eb-9536-d445409322c5.png)

# After:
<img width="744" alt="Screenshot 2021-04-01 at 17 50 58" src="https://user-images.githubusercontent.com/29529/113320565-eaa04b00-9312-11eb-9c1d-ea8737c7fb21.png">
