### PR TITLE
fix:changing regex to allow 0 in the queryID

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: https://www.algolia.com
 documentation: https://github.com/algolia/search-insights-gtm
 versions:
+  - sha: 16ba3414aa9a12ea555cb0a5fea00c400f9934f0
+    changeNotes: fix:changing regex to allow 0 in the queryID
   - sha: ad7f475b8ac1f3d3364be4bd3d2e72d4a4d512ee
     changeNotes: "fix(groupNames): looks like those names cannot have spaces (#4)"
   - sha: 84f59041da3e8fded75b7f5904ff88fbdd486055

--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -369,7 +369,7 @@
         "type": "TEXT",
         "valueValidators": [
           {
-            "args": ["[a-z1-9]{32}"],
+            "args": ["[a-z0-9]{32}"],
             "type": "REGEX"
           }
         ],

--- a/template.tpl
+++ b/template.tpl
@@ -396,7 +396,7 @@ ___TEMPLATE_PARAMETERS___
         "type": "TEXT",
         "valueValidators": [
           {
-            "args": ["[a-z1-9]{32}"],
+            "args": ["[a-z0-9]{32}"],
             "type": "REGEX"
           }
         ],


### PR DESCRIPTION
The regex for query id will not match query ids which contain a 0:

https://regex101.com/r/dVJKLw/1

<img width="1628" alt="Screenshot 2021-08-31 at 18 18 11" src="https://user-images.githubusercontent.com/59652368/131547539-abdc45f7-3507-4564-8da3-4c58c929f988.png">

I think we need to change the regex to allow a 0:

https://regex101.com/r/40yYZX/1

<img width="1608" alt="Screenshot 2021-08-31 at 18 18 02" src="https://user-images.githubusercontent.com/59652368/131547536-cca26348-4337-4d78-b77d-15bd6350bb9f.png">