### PR TITLE
feat: upgrade search-insights and remove validations

### DIFF
--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -264,31 +264,12 @@
         "name": "cookieDuration",
         "help": "The cookie duration in milliseconds (default to `15552000000`, 6 months).",
         "type": "TEXT",
-        "simpleValueType": true,
-        "valueValidators": [
-          {
-            "type": "POSITIVE_NUMBER"
-          }
-        ]
+        "simpleValueType": true
       },
       {
         "displayName": "User Token",
         "name": "initialUserToken",
         "help": "Set an initial user identifier applied to subsequent events.",
-        "type": "TEXT",
-        "simpleValueType": true,
-        "valueValidators": [
-          {
-            "args": ["^.{1,64}$"],
-            "type": "REGEX"
-          }
-        ]
-      },
-      {
-        "displayName": "Search Insights Source URL",
-        "name": "searchInsightsSource",
-        "defaultValue": "https://cdn.jsdelivr.net/npm/search-insights@1.8.0",
-        "help": "The source URL of the Search Insights library.",
         "type": "TEXT",
         "simpleValueType": true
       }
@@ -312,22 +293,10 @@
         "name": "userToken",
         "help": "The identifier of the user.",
         "type": "TEXT",
-        "simpleValueType": true,
-        "valueValidators": [
-          {
-            "args": ["^.{1,64}$"],
-            "type": "REGEX"
-          }
-        ]
+        "simpleValueType": true
       },
       {
         "help": "The name of the event.",
-        "valueValidators": [
-          {
-            "args": ["^.{1,64}$"],
-            "type": "REGEX"
-          }
-        ],
         "displayName": "Event Name",
         "simpleValueType": true,
         "name": "eventName",
@@ -346,12 +315,6 @@
         "help": "The list of object IDs separated by commas (maximum of 20).",
         "simpleValueType": true,
         "type": "TEXT",
-        "valueValidators": [
-          {
-            "args": [1, 20],
-            "type": "TABLE_ROW_COUNT"
-          }
-        ],
         "enablingConditions": [
           {
             "paramName": "method",
@@ -386,12 +349,6 @@
         "help": "The `queryID` of the search sent from Algolia (<a href=\"https://www.algolia.com/doc/api-reference/api-parameters/clickAnalytics/\">`clickAnalytics`</a> needs to be set)",
         "simpleValueType": true,
         "type": "TEXT",
-        "valueValidators": [
-          {
-            "args": ["[a-z0-9]{32}"],
-            "type": "REGEX"
-          }
-        ],
         "enablingConditions": [
           {
             "paramName": "method",

--- a/src/template.js
+++ b/src/template.js
@@ -29,6 +29,7 @@ switch (data.method) {
   case 'init': {
     if (isInitialized()) {
       logger('The "init" event has already been called.');
+      data.gtmOnFailure();
       break;
     }
 
@@ -47,8 +48,13 @@ switch (data.method) {
           '"\n\n' +
           'See https://www.simoahava.com/analytics/custom-templates-guide-for-google-tag-manager/#step-4-modify-permissions'
       );
+      data.gtmOnFailure();
       break;
     }
+
+    log(
+      '[INFO] Algolia GTM template no longer validates event payloads.\nYou can visit https://algolia.com/events/debugger instead.'
+    );
 
     const initOptions = {
       appId: data.appId,
@@ -79,6 +85,7 @@ switch (data.method) {
   case 'viewedObjectIDs': {
     if (!isInitialized()) {
       logger('You need to call the "init" event first.');
+      data.gtmOnFailure();
       break;
     }
 
@@ -91,13 +98,14 @@ switch (data.method) {
 
     logger(data.method, viewedObjectIDsOptions);
     aa(data.method, viewedObjectIDsOptions);
-
+    data.gtmOnSuccess();
     break;
   }
 
   case 'clickedObjectIDsAfterSearch': {
     if (!isInitialized()) {
       logger('You need to call the "init" event first.');
+      data.gtmOnFailure();
       break;
     }
 
@@ -112,13 +120,14 @@ switch (data.method) {
 
     logger(data.method, clickedObjectIDsAfterSearchOptions);
     aa(data.method, clickedObjectIDsAfterSearchOptions);
-
+    data.gtmOnSuccess();
     break;
   }
 
   case 'clickedObjectIDs': {
     if (!isInitialized()) {
       logger('You need to call the "init" event first.');
+      data.gtmOnFailure();
       break;
     }
 
@@ -132,13 +141,14 @@ switch (data.method) {
 
     logger(data.method, clickedObjectIDsOptions);
     aa(data.method, clickedObjectIDsOptions);
-
+    data.gtmOnSuccess();
     break;
   }
 
   case 'clickedFilters': {
     if (!isInitialized()) {
       logger('You need to call the "init" event first.');
+      data.gtmOnFailure();
       break;
     }
 
@@ -151,13 +161,14 @@ switch (data.method) {
 
     logger(data.method, clickedFiltersOptions);
     aa(data.method, clickedFiltersOptions);
-
+    data.gtmOnSuccess();
     break;
   }
 
   case 'convertedObjectIDsAfterSearch': {
     if (!isInitialized()) {
       logger('You need to call the "init" event first.');
+      data.gtmOnFailure();
       break;
     }
 
@@ -171,13 +182,14 @@ switch (data.method) {
 
     logger(data.method, convertedObjectIDsAfterSearchOptions);
     aa(data.method, convertedObjectIDsAfterSearchOptions);
-
+    data.gtmOnSuccess();
     break;
   }
 
   case 'convertedObjectIDs': {
     if (!isInitialized()) {
       logger('You need to call the "init" event first.');
+      data.gtmOnFailure();
       break;
     }
 
@@ -190,13 +202,14 @@ switch (data.method) {
 
     logger(data.method, convertedObjectIDsOptions);
     aa(data.method, convertedObjectIDsOptions);
-
+    data.gtmOnSuccess();
     break;
   }
 
   case 'convertedFilters': {
     if (!isInitialized()) {
       logger('You need to call the "init" event first.');
+      data.gtmOnFailure();
       break;
     }
 
@@ -209,13 +222,14 @@ switch (data.method) {
 
     logger(data.method, convertedFiltersOptions);
     aa(data.method, convertedFiltersOptions);
-
+    data.gtmOnSuccess();
     break;
   }
 
   case 'viewedFilters': {
     if (!isInitialized()) {
       logger('You need to call the "init" event first.');
+      data.gtmOnFailure();
       break;
     }
 
@@ -228,7 +242,7 @@ switch (data.method) {
 
     logger(data.method, viewedFiltersOptions);
     aa(data.method, viewedFiltersOptions);
-
+    data.gtmOnSuccess();
     break;
   }
 

--- a/src/template.js
+++ b/src/template.js
@@ -9,7 +9,7 @@ const makeInteger = require('makeInteger');
 const TEMPLATE_VERSION = '1.1.0';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
 const INSIGHTS_LIBRARY_URL =
-  'https://cdn.jsdelivr.net/npm/search-insights@2.0.3';
+  'https://cdn.jsdelivr.net/npm/search-insights@2.0.4';
 const aa = createArgumentsQueue('aa', 'aa.queue');
 
 function isInitialized() {

--- a/src/template.js
+++ b/src/template.js
@@ -8,6 +8,8 @@ const makeInteger = require('makeInteger');
 
 const TEMPLATE_VERSION = '1.1.0';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
+const INSIGHTS_LIBRARY_URL =
+  'https://cdn.jsdelivr.net/npm/search-insights@2.0.3';
 const aa = createArgumentsQueue('aa', 'aa.queue');
 
 function isInitialized() {
@@ -30,18 +32,18 @@ switch (data.method) {
       break;
     }
 
-    if (queryPermission('inject_script', data.searchInsightsSource)) {
+    if (queryPermission('inject_script', INSIGHTS_LIBRARY_URL)) {
       injectScript(
-        data.searchInsightsSource,
+        INSIGHTS_LIBRARY_URL,
         data.gtmOnSuccess,
         data.gtmOnFailure,
-        data.searchInsightsSource
+        INSIGHTS_LIBRARY_URL
       );
     } else {
       logger(
         'The library endpoint is not allowed in the "Injects Scripts" permissions.\n\n' +
           'You need to add the value: "' +
-          data.searchInsightsSource +
+          'https://cdn.jsdelivr.net/npm/search-insights*' +
           '"\n\n' +
           'See https://www.simoahava.com/analytics/custom-templates-guide-for-google-tag-manager/#step-4-modify-permissions'
       );
@@ -54,6 +56,7 @@ switch (data.method) {
       userHasOptedOut: data.userHasOptedOut,
       region: data.region,
       cookieDuration: data.cookieDuration,
+      useCookie: data.useCookie === false ? false : true, // true by default
     };
 
     logger(data.method, initOptions);

--- a/src/template.js
+++ b/src/template.js
@@ -248,5 +248,6 @@ switch (data.method) {
 
   default: {
     logger('You need to set the method for this event.');
+    data.gtmOnFailure();
   }
 }


### PR DESCRIPTION
## Summary

This PR upgrades does a few things regarding search-insights and validation:

* embed the url of search-insights inside the code (it was an option to user and we couldn't enforce a specific version of search-insights before)
* upgrade search-insights to 2.0.4 (which removes validation logic from the library)
* remove validation on GTM input fields
* finish each method with either success or failure (previously it was appeared as "Still Running" on GTM)