### PR TITLE
fix: use iife in case requirejs is included in customers' website

### DIFF
--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -272,6 +272,25 @@
         "help": "Set an initial user identifier applied to subsequent events.",
         "type": "TEXT",
         "simpleValueType": true
+      },
+      {
+        "displayName": "Use IIFE bundle",
+        "name": "useIIFE",
+        "help": "If your website has RequireJS, use IIFE bundle of search-insights to avoid any issue. (False by default)",
+        "type": "SELECT",
+        "macrosInSelect": true,
+        "simpleValueType": true,
+        "notSetText": "",
+        "selectItems": [
+          {
+            "displayValue": "False",
+            "value": false
+          },
+          {
+            "displayValue": "True",
+            "value": true
+          }
+        ]
       }
     ]
   },

--- a/src/template.js
+++ b/src/template.js
@@ -10,7 +10,9 @@ const getType = require('getType');
 const TEMPLATE_VERSION = '1.2.1';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
 const INSIGHTS_LIBRARY_URL =
-  'https://cdn.jsdelivr.net/npm/search-insights@2.0.4';
+  'https://cdn.jsdelivr.net/npm/search-insights@2.0.4' +
+  (!!copyFromWindow('requirejs') ? '/dist/search-insights.iife.min.js' : '');
+
 const aa = createArgumentsQueue('aa', 'aa.queue');
 
 function isInitialized() {

--- a/src/template.js
+++ b/src/template.js
@@ -27,7 +27,8 @@ function formatValueToList(value) {
 
 function getLibraryURL(useIIFE) {
   return (
-    INSIGHTS_LIBRARY_URL + (useIIFE ? '/dist/search-insights.iife.min.js' : '')
+    INSIGHTS_LIBRARY_URL +
+    (useIIFE === true ? '/dist/search-insights.iife.min.js' : '')
   );
 }
 

--- a/src/template.js
+++ b/src/template.js
@@ -6,12 +6,12 @@ const setInWindow = require('setInWindow');
 const copyFromWindow = require('copyFromWindow');
 const makeInteger = require('makeInteger');
 const getType = require('getType');
+const callLater = require('callLater');
 
 const TEMPLATE_VERSION = '1.2.1';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
 const INSIGHTS_LIBRARY_URL =
-  'https://cdn.jsdelivr.net/npm/search-insights@2.0.4' +
-  (!!copyFromWindow('requirejs') ? '/dist/search-insights.iife.min.js' : '');
+  'https://cdn.jsdelivr.net/npm/search-insights@2.0.4';
 
 const aa = createArgumentsQueue('aa', 'aa.queue');
 
@@ -23,6 +23,12 @@ function formatValueToList(value) {
   const array = getType(value) === 'array' ? value : value.split(',');
   // TODO: do not remove the rest, but split into multiple events as soon as search-insights support batch events.
   return array.slice(0, 20);
+}
+
+function getLibraryURL(useIIFE) {
+  return (
+    INSIGHTS_LIBRARY_URL + (useIIFE ? '/dist/search-insights.iife.min.js' : '')
+  );
 }
 
 function logger(message, event) {
@@ -37,12 +43,37 @@ switch (data.method) {
       break;
     }
 
-    if (queryPermission('inject_script', INSIGHTS_LIBRARY_URL)) {
+    const url = getLibraryURL(data.useIIFE);
+
+    if (queryPermission('inject_script', url)) {
       injectScript(
-        INSIGHTS_LIBRARY_URL,
-        data.gtmOnSuccess,
+        url,
+        () => {
+          if (!copyFromWindow('aa')) {
+            data.gtmOnFailure();
+            logger('[ERROR] Failed to load search-insights.');
+            return;
+          }
+
+          let libraryLoaded = false;
+          aa('getUserToken', null, () => {
+            // call any method to see if it reacts.
+            libraryLoaded = true;
+          });
+          callLater(() => {
+            if (libraryLoaded) {
+              data.gtmOnSuccess();
+            } else {
+              log(
+                '[ERROR] Failed to load search-insights.\n\n' +
+                  'If your website is using RequireJS, you need to turn on "Use IIFE" option of Initialization method.'
+              );
+              data.gtmOnFailure();
+            }
+          });
+        },
         data.gtmOnFailure,
-        INSIGHTS_LIBRARY_URL
+        url
       );
     } else {
       logger(

--- a/src/template.js
+++ b/src/template.js
@@ -6,7 +6,6 @@ const setInWindow = require('setInWindow');
 const copyFromWindow = require('copyFromWindow');
 const makeInteger = require('makeInteger');
 const getType = require('getType');
-const callLater = require('callLater');
 
 const TEMPLATE_VERSION = '1.2.1';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
@@ -57,21 +56,20 @@ switch (data.method) {
           }
 
           let libraryLoaded = false;
+          // call any method to see if it reacts.
+          // `getUserToken` is syncronous, so it updates the flag immediately.
           aa('getUserToken', null, () => {
-            // call any method to see if it reacts.
             libraryLoaded = true;
           });
-          callLater(() => {
-            if (libraryLoaded) {
-              data.gtmOnSuccess();
-            } else {
-              log(
-                '[ERROR] Failed to load search-insights.\n\n' +
-                  'If your website is using RequireJS, you need to turn on "Use IIFE" option of Initialization method.'
-              );
-              data.gtmOnFailure();
-            }
-          });
+          if (libraryLoaded) {
+            data.gtmOnSuccess();
+          } else {
+            log(
+              '[ERROR] Failed to load search-insights.\n\n' +
+                'If your website is using RequireJS, you need to turn on "Use IIFE" option of Initialization method.'
+            );
+            data.gtmOnFailure();
+          }
         },
         data.gtmOnFailure,
         url


### PR DESCRIPTION
## Summary

This PR selectively loads iife version of search-insights in case `requirejs` is included in customers' website, because requirejs clashes with umd version of search-insights (ref: https://github.com/algolia/search-insights.js/pull/274)

Especially, we've seen requirejs being used in Magento 2. The url of search-insights is hard-coded in the template. If we don't provide this, user will have to modify the template by themselves which will make a fork, thus they won't get update in the future.