### PR TITLE
feat: chunk events with items exceeding limits

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -52,7 +52,7 @@ function chunkPayload(payload, keys, limit) {
   const numberOfChunks = Math.ceil(payload[keys[0]].length / limit);
   const chunks = [];
   for (let i = 0; i < numberOfChunks; i++) {
-    const newPayload = clone(payload);
+    const newPayload = shallowObjectClone(payload);
     keys.forEach((key) => {
       newPayload[key] = payload[key].slice(i * limit, (i + 1) * limit);
     });

--- a/src/template.js
+++ b/src/template.js
@@ -6,11 +6,15 @@ const setInWindow = require('setInWindow');
 const copyFromWindow = require('copyFromWindow');
 const makeInteger = require('makeInteger');
 const getType = require('getType');
+const Math = require('Math');
 
 const TEMPLATE_VERSION = '1.2.1';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
 const INSIGHTS_LIBRARY_URL =
   'https://cdn.jsdelivr.net/npm/search-insights@2.0.4';
+
+const MAX_OBJECT_IDS = 20;
+const MAX_FILTERS = 10;
 
 const aa = createArgumentsQueue('aa', 'aa.queue');
 
@@ -33,6 +37,19 @@ function getLibraryURL(useIIFE) {
 
 function logger(message, event) {
   log('[GTM-DEBUG] Search Insights > ' + message, event || '');
+}
+
+function chunkPayload(payload, key, limit) {
+  const numberOfChunks = Math.ceil(payload[key].length / limit);
+  const chunks = [];
+  for (let i = 0; i < numberOfChunks; i++) {
+    chunks.push(
+      Object.assign(payload, {
+        [key]: payload[key].slice(i * limit, (i + 1) * limit),
+      })
+    );
+  }
+  return chunks;
 }
 
 switch (data.method) {
@@ -123,15 +140,17 @@ switch (data.method) {
       break;
     }
 
-    const viewedObjectIDsOptions = {
+    const payload = {
+      eventType: 'view',
       eventName: data.eventName,
       index: data.index,
       objectIDs: formatValueToList(data.objectIDs),
       userToken: data.userToken,
     };
+    const chunks = chunkPayload(payload, 'objectIDs', MAX_OBJECT_IDS);
 
-    logger(data.method, viewedObjectIDsOptions);
-    aa(data.method, viewedObjectIDsOptions);
+    logger('sendEvents', chunks);
+    aa('sendEvents', chunks);
     data.gtmOnSuccess();
     break;
   }
@@ -143,7 +162,8 @@ switch (data.method) {
       break;
     }
 
-    const clickedObjectIDsAfterSearchOptions = {
+    const payload = {
+      eventType: 'click',
       eventName: data.eventName,
       index: data.index,
       objectIDs: formatValueToList(data.objectIDs),
@@ -151,9 +171,10 @@ switch (data.method) {
       queryID: data.queryID,
       userToken: data.userToken,
     };
+    const chunks = chunkPayload(payload, 'objectIDs', MAX_OBJECT_IDS);
 
-    logger(data.method, clickedObjectIDsAfterSearchOptions);
-    aa(data.method, clickedObjectIDsAfterSearchOptions);
+    logger('sendEvents', chunks);
+    aa('sendEvents', chunks);
     data.gtmOnSuccess();
     break;
   }
@@ -165,16 +186,18 @@ switch (data.method) {
       break;
     }
 
-    const clickedObjectIDsOptions = {
+    const payload = {
+      eventType: 'click',
       eventName: data.eventName,
       index: data.index,
       queryID: data.queryID,
       objectIDs: formatValueToList(data.objectIDs),
       userToken: data.userToken,
     };
+    const chunks = chunkPayload(payload, 'objectIDs', MAX_OBJECT_IDS);
 
-    logger(data.method, clickedObjectIDsOptions);
-    aa(data.method, clickedObjectIDsOptions);
+    logger('sendEvents', chunks);
+    aa('sendEvents', chunks);
     data.gtmOnSuccess();
     break;
   }
@@ -186,15 +209,17 @@ switch (data.method) {
       break;
     }
 
-    const clickedFiltersOptions = {
+    const payload = {
+      eventType: 'click',
       eventName: data.eventName,
       filters: formatValueToList(data.filters),
       index: data.index,
       userToken: data.userToken,
     };
+    const chunks = chunkPayload(payload, 'filters', MAX_FILTERS);
 
-    logger(data.method, clickedFiltersOptions);
-    aa(data.method, clickedFiltersOptions);
+    logger('sendEvents', chunks);
+    aa('sendEvents', chunks);
     data.gtmOnSuccess();
     break;
   }
@@ -206,16 +231,18 @@ switch (data.method) {
       break;
     }
 
-    const convertedObjectIDsAfterSearchOptions = {
+    const payload = {
+      eventType: 'conversion',
       eventName: data.eventName,
       index: data.index,
       objectIDs: formatValueToList(data.objectIDs),
       queryID: data.queryID,
       userToken: data.userToken,
     };
+    const chunks = chunkPayload(payload, 'objectIDs', MAX_OBJECT_IDS);
 
-    logger(data.method, convertedObjectIDsAfterSearchOptions);
-    aa(data.method, convertedObjectIDsAfterSearchOptions);
+    logger('sendEvents', chunks);
+    aa('sendEvents', chunks);
     data.gtmOnSuccess();
     break;
   }
@@ -227,15 +254,17 @@ switch (data.method) {
       break;
     }
 
-    const convertedObjectIDsOptions = {
+    const payload = {
+      eventType: 'conversion',
       eventName: data.eventName,
       index: data.index,
       objectIDs: formatValueToList(data.objectIDs),
       userToken: data.userToken,
     };
+    const chunks = chunkPayload(payload, 'objectIDs', MAX_OBJECT_IDS);
 
-    logger(data.method, convertedObjectIDsOptions);
-    aa(data.method, convertedObjectIDsOptions);
+    logger('sendEvents', chunks);
+    aa('sendEvents', chunks);
     data.gtmOnSuccess();
     break;
   }
@@ -247,15 +276,17 @@ switch (data.method) {
       break;
     }
 
-    const convertedFiltersOptions = {
+    const payload = {
+      eventType: 'conversion',
       eventName: data.eventName,
       filters: formatValueToList(data.filters),
       index: data.index,
       userToken: data.userToken,
     };
+    const chunks = chunkPayload(payload, 'filters', MAX_FILTERS);
 
-    logger(data.method, convertedFiltersOptions);
-    aa(data.method, convertedFiltersOptions);
+    logger('sendEvents', chunks);
+    aa('sendEvents', chunks);
     data.gtmOnSuccess();
     break;
   }
@@ -267,15 +298,17 @@ switch (data.method) {
       break;
     }
 
-    const viewedFiltersOptions = {
+    const payload = {
+      eventType: 'view',
       eventName: data.eventName,
       filters: formatValueToList(data.filters),
       index: data.index,
       userToken: data.userToken,
     };
+    const chunks = chunkPayload(payload, 'filters', MAX_FILTERS);
 
-    logger(data.method, viewedFiltersOptions);
-    aa(data.method, viewedFiltersOptions);
+    logger('sendEvents', chunks);
+    aa('sendEvents', chunks);
     data.gtmOnSuccess();
     break;
   }

--- a/src/template.js
+++ b/src/template.js
@@ -23,9 +23,7 @@ function isInitialized() {
 }
 
 function formatValueToList(value) {
-  const array = getType(value) === 'array' ? value : value.split(',');
-  // TODO: do not remove the rest, but split into multiple events as soon as search-insights support batch events.
-  return array.slice(0, 20);
+  return getType(value) === 'array' ? value : value.split(',');
 }
 
 function getLibraryURL(useIIFE) {
@@ -39,15 +37,17 @@ function logger(message, event) {
   log('[GTM-DEBUG] Search Insights > ' + message, event || '');
 }
 
-function chunkPayload(payload, key, limit) {
-  const numberOfChunks = Math.ceil(payload[key].length / limit);
+function chunkPayload(payload, keys, limit) {
+  // This assumes the values of `keys` have the same length.
+  const numberOfChunks = Math.ceil(payload[keys[0]].length / limit);
   const chunks = [];
   for (let i = 0; i < numberOfChunks; i++) {
-    chunks.push(
-      Object.assign(payload, {
-        [key]: payload[key].slice(i * limit, (i + 1) * limit),
-      })
-    );
+    const newPayload = Object.assign({}, payload);
+    keys.forEach((key) => {
+      newPayload[key] = payload[key].slice(i * limit, (i + 1) * limit);
+    });
+
+    chunks.push(newPayload);
   }
   return chunks;
 }
@@ -147,7 +147,7 @@ switch (data.method) {
       objectIDs: formatValueToList(data.objectIDs),
       userToken: data.userToken,
     };
-    const chunks = chunkPayload(payload, 'objectIDs', MAX_OBJECT_IDS);
+    const chunks = chunkPayload(payload, ['objectIDs'], MAX_OBJECT_IDS);
 
     logger('sendEvents', chunks);
     aa('sendEvents', chunks);
@@ -171,7 +171,11 @@ switch (data.method) {
       queryID: data.queryID,
       userToken: data.userToken,
     };
-    const chunks = chunkPayload(payload, 'objectIDs', MAX_OBJECT_IDS);
+    const chunks = chunkPayload(
+      payload,
+      ['objectIDs', 'positions'],
+      MAX_OBJECT_IDS
+    );
 
     logger('sendEvents', chunks);
     aa('sendEvents', chunks);
@@ -194,7 +198,7 @@ switch (data.method) {
       objectIDs: formatValueToList(data.objectIDs),
       userToken: data.userToken,
     };
-    const chunks = chunkPayload(payload, 'objectIDs', MAX_OBJECT_IDS);
+    const chunks = chunkPayload(payload, ['objectIDs'], MAX_OBJECT_IDS);
 
     logger('sendEvents', chunks);
     aa('sendEvents', chunks);
@@ -216,7 +220,7 @@ switch (data.method) {
       index: data.index,
       userToken: data.userToken,
     };
-    const chunks = chunkPayload(payload, 'filters', MAX_FILTERS);
+    const chunks = chunkPayload(payload, ['filters'], MAX_FILTERS);
 
     logger('sendEvents', chunks);
     aa('sendEvents', chunks);
@@ -239,7 +243,7 @@ switch (data.method) {
       queryID: data.queryID,
       userToken: data.userToken,
     };
-    const chunks = chunkPayload(payload, 'objectIDs', MAX_OBJECT_IDS);
+    const chunks = chunkPayload(payload, ['objectIDs'], MAX_OBJECT_IDS);
 
     logger('sendEvents', chunks);
     aa('sendEvents', chunks);
@@ -261,7 +265,7 @@ switch (data.method) {
       objectIDs: formatValueToList(data.objectIDs),
       userToken: data.userToken,
     };
-    const chunks = chunkPayload(payload, 'objectIDs', MAX_OBJECT_IDS);
+    const chunks = chunkPayload(payload, ['objectIDs'], MAX_OBJECT_IDS);
 
     logger('sendEvents', chunks);
     aa('sendEvents', chunks);
@@ -283,7 +287,7 @@ switch (data.method) {
       index: data.index,
       userToken: data.userToken,
     };
-    const chunks = chunkPayload(payload, 'filters', MAX_FILTERS);
+    const chunks = chunkPayload(payload, ['filters'], MAX_FILTERS);
 
     logger('sendEvents', chunks);
     aa('sendEvents', chunks);
@@ -305,7 +309,7 @@ switch (data.method) {
       index: data.index,
       userToken: data.userToken,
     };
-    const chunks = chunkPayload(payload, 'filters', MAX_FILTERS);
+    const chunks = chunkPayload(payload, ['filters'], MAX_FILTERS);
 
     logger('sendEvents', chunks);
     aa('sendEvents', chunks);

--- a/src/template.js
+++ b/src/template.js
@@ -48,7 +48,16 @@ function shallowObjectClone(obj) {
 }
 
 function chunkPayload(payload, keys, limit) {
-  // This assumes the values of `keys` have the same length.
+  // check if the values in `payload` for each of `keys` have the same length.
+  const sameNumberOfValues = keys
+    .map((k) => payload[k].length)
+    .every((n) => n === payload[keys[0]].length);
+  if (!sameNumberOfValues) {
+    // chunking behaviour is unsafe due to unequal length arrays to chunk.
+    // bail out early.
+    return [payload];
+  }
+
   const numberOfChunks = Math.ceil(payload[keys[0]].length / limit);
   const chunks = [];
   for (let i = 0; i < numberOfChunks; i++) {

--- a/src/template.js
+++ b/src/template.js
@@ -38,7 +38,7 @@ function logger(message, event) {
   log('[GTM-DEBUG] Search Insights > ' + message, event || '');
 }
 
-function clone(obj) {
+function shallowObjectClone(obj) {
   const keys = Object.keys(obj);
   const newObj = {};
   keys.forEach((key) => {

--- a/src/template.js
+++ b/src/template.js
@@ -7,6 +7,7 @@ const copyFromWindow = require('copyFromWindow');
 const makeInteger = require('makeInteger');
 const getType = require('getType');
 const Math = require('Math');
+const Object = require('Object');
 
 const TEMPLATE_VERSION = '1.2.1';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
@@ -37,12 +38,21 @@ function logger(message, event) {
   log('[GTM-DEBUG] Search Insights > ' + message, event || '');
 }
 
+function clone(obj) {
+  const keys = Object.keys(obj);
+  const newObj = {};
+  keys.forEach((key) => {
+    newObj[key] = obj[key];
+  });
+  return newObj;
+}
+
 function chunkPayload(payload, keys, limit) {
   // This assumes the values of `keys` have the same length.
   const numberOfChunks = Math.ceil(payload[keys[0]].length / limit);
   const chunks = [];
   for (let i = 0; i < numberOfChunks; i++) {
-    const newPayload = Object.assign({}, payload);
+    const newPayload = clone(payload);
     keys.forEach((key) => {
       newPayload[key] = payload[key].slice(i * limit, (i + 1) * limit);
     });


### PR DESCRIPTION
Before this PR, it used to slice objectIDs or filters to fit in the API limitation, which results to missing values in the request.

In this PR, it chunks the payload into multiple if it exceeds the limit. This is possible now due to the addition of [the new `sendEvents` method](https://github.com/algolia/search-insights.js/pull/335) in search-insights. However, it's not released on search-insights side yet. So we need to wait for it first.

Another context: There was no mention about filter events in the GTM documentation. Now that we're about to add it, the limit of 10 for filters will likely cause issues if customers have many filters on their website (especially with filter view event.)