### PR TITLE
fix: allow number in formatValueToList

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -24,7 +24,16 @@ function isInitialized() {
 }
 
 function formatValueToList(value) {
-  return getType(value) === 'array' ? value : value.split(',');
+  const type = getType(value);
+  if (type === 'array') {
+    return value;
+  } else if (type === 'number') {
+    return [value];
+  } else if (type === 'string') {
+    return value.split(',');
+  } else {
+    return null;
+  }
 }
 
 function getLibraryURL(useIIFE) {


### PR DESCRIPTION
## Summary

When users send integer as variable, `formatValueToList` fails. This PR allows the integer value to become an array of it as-is.

This can happen when users send data via `dataLayer` (not via data-* attributes on the DOM).