### PR TITLE
fix: support None / empty string in eventSubtype

### DIFF
--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -322,12 +322,16 @@
         "type": "TEXT"
       },
       {
-        "help": "The specific type of conversion event.",
+        "help": "The specific type of conversion event. Set to 'None' for conversion events that do not have a subtype.",
         "displayName": "Conversion Event Subtype",
         "simpleValueType": true,
         "name": "eventSubtype",
         "type": "SELECT",
         "selectItems": [
+          {
+            "displayValue": "None",
+            "value": ""
+          },
           {
             "displayValue": "Add to cart",
             "value": "addToCart"

--- a/src/template.js
+++ b/src/template.js
@@ -265,13 +265,15 @@ switch (data.method) {
 
     const payload = {
       eventType: 'conversion',
-      eventSubtype: data.eventSubtype,
       eventName: data.eventName,
       index: data.index,
       objectIDs: formatValueToList(data.objectIDs),
       queryID: data.queryID,
       userToken: data.userToken,
     };
+    if (data.eventSubtype) {
+      payload.eventSubtype = data.eventSubtype;
+    }
     const chunks = chunkPayload(payload, ['objectIDs'], MAX_OBJECT_IDS);
 
     logger('sendEvents', chunks);
@@ -289,12 +291,14 @@ switch (data.method) {
 
     const payload = {
       eventType: 'conversion',
-      eventSubtype: data.eventSubtype,
       eventName: data.eventName,
       index: data.index,
       objectIDs: formatValueToList(data.objectIDs),
       userToken: data.userToken,
     };
+    if (data.eventSubtype) {
+      payload.eventSubtype = data.eventSubtype;
+    }
     const chunks = chunkPayload(payload, ['objectIDs'], MAX_OBJECT_IDS);
 
     logger('sendEvents', chunks);
@@ -312,12 +316,14 @@ switch (data.method) {
 
     const payload = {
       eventType: 'conversion',
-      eventSubtype: data.eventSubtype,
       eventName: data.eventName,
       filters: formatValueToList(data.filters),
       index: data.index,
       userToken: data.userToken,
     };
+    if (data.eventSubtype) {
+      payload.eventSubtype = data.eventSubtype;
+    }
     const chunks = chunkPayload(payload, ['filters'], MAX_FILTERS);
 
     logger('sendEvents', chunks);


### PR DESCRIPTION
https://github.com/algolia/search-insights-gtm/pull/18 added support for eventSubtype but an empty string option was left out of the select, unintentionally forcing users to pick a subtype for their conversion events.

EEX-780