### PR TITLE
feat: add objectData support

### DIFF
--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -401,6 +401,65 @@
         ]
       },
       {
+        "type": "SIMPLE_TABLE",
+        "name": "objectData",
+        "displayName": "Object Data",
+        "help": "A list of data containing additional information about associated objects (maximum of 20).",
+        "enablingConditions": [
+          {
+            "paramName": "method",
+            "type": "EQUALS",
+            "paramValue": "viewedObjectIDs"
+          },
+          {
+            "paramName": "method",
+            "type": "EQUALS",
+            "paramValue": "clickedObjectIDsAfterSearch"
+          },
+          {
+            "paramName": "method",
+            "type": "EQUALS",
+            "paramValue": "clickedObjectIDs"
+          },
+          {
+            "paramName": "method",
+            "type": "EQUALS",
+            "paramValue": "convertedObjectIDsAfterSearch"
+          },
+          {
+            "paramName": "method",
+            "type": "EQUALS",
+            "paramValue": "convertedObjectIDs"
+          }
+        ],
+        "simpleTableColumns": [
+          {
+            "defaultValue": "",
+            "displayName": "Query ID",
+            "name": "queryID",
+            "type": "TEXT"
+          },
+          {
+            "defaultValue": "",
+            "displayName": "Price",
+            "name": "price",
+            "type": "TEXT"
+          },
+          {
+            "defaultValue": "",
+            "displayName": "Discount",
+            "name": "discount",
+            "type": "TEXT"
+          },
+          {
+            "defaultValue": "",
+            "displayName": "Quantity",
+            "name": "quantity",
+            "type": "TEXT"
+          }
+        ]
+      },
+      {
         "displayName": "Query ID",
         "name": "queryID",
         "help": "The `queryID` of the search sent from Algolia (<a href=\"https://www.algolia.com/doc/api-reference/api-parameters/clickAnalytics/\">`clickAnalytics`</a> needs to be set)",

--- a/src/template.js
+++ b/src/template.js
@@ -47,12 +47,12 @@ function transformObjectData(objectData) {
     }
 
     // The API expects price to be a number so delete it entirely if empty.
-    if (getType(od.price) === 'string' && !od.price) {
+    if (getType(od.price) === 'string' && od.price === '') {
       od.price = undefined;
     }
 
     // The API expects discount to be a number so delete it entirely if empty.
-    if (getType(od.discount) === 'string' && !od.discount) {
+    if (getType(od.discount) === 'string' && od.discount === '') {
       od.discount = undefined;
     }
 

--- a/src/template.js
+++ b/src/template.js
@@ -36,6 +36,41 @@ function formatValueToList(value) {
   }
 }
 
+function transformObjectData(objectData) {
+  if (getType(objectData) !== 'array') {
+    return objectData;
+  }
+
+  return objectData.map((od) => {
+    if (getType(od) !== 'object') {
+      return od;
+    }
+
+    // The API expects price to be a number so delete it entirely if empty.
+    if (getType(od.price) === 'string' && !od.price) {
+      od.price = undefined;
+    }
+
+    // The API expects discount to be a number so delete it entirely if empty.
+    if (getType(od.discount) === 'string' && !od.discount) {
+      od.discount = undefined;
+    }
+
+    // The API expects quantity to be an integer.
+    // If quantity is empty, then delete it entirely because the API allows
+    // quantity to be omitted from the event payload.
+    if (getType(od.quantity) === 'string') {
+      if (od.quantity) {
+        od.quantity = makeInteger(od.quantity);
+      } else {
+        od.quantity = undefined;
+      }
+    }
+
+    return od;
+  });
+}
+
 function getLibraryURL(useIIFE) {
   return (
     INSIGHTS_LIBRARY_URL +
@@ -173,6 +208,7 @@ switch (data.method) {
       eventName: data.eventName,
       index: data.index,
       objectIDs: formatValueToList(data.objectIDs),
+      objectData: transformObjectData(data.objectData),
       userToken: data.userToken,
     };
     const chunks = chunkPayload(payload, ['objectIDs'], MAX_OBJECT_IDS);
@@ -195,6 +231,7 @@ switch (data.method) {
       eventName: data.eventName,
       index: data.index,
       objectIDs: formatValueToList(data.objectIDs),
+      objectData: transformObjectData(data.objectData),
       positions: formatValueToList(data.positions).map(makeInteger),
       queryID: data.queryID,
       userToken: data.userToken,
@@ -224,6 +261,7 @@ switch (data.method) {
       index: data.index,
       queryID: data.queryID,
       objectIDs: formatValueToList(data.objectIDs),
+      objectData: transformObjectData(data.objectData),
       userToken: data.userToken,
     };
     const chunks = chunkPayload(payload, ['objectIDs'], MAX_OBJECT_IDS);
@@ -268,6 +306,7 @@ switch (data.method) {
       eventName: data.eventName,
       index: data.index,
       objectIDs: formatValueToList(data.objectIDs),
+      objectData: transformObjectData(data.objectData),
       queryID: data.queryID,
       userToken: data.userToken,
       value: data.value,
@@ -296,6 +335,7 @@ switch (data.method) {
       eventName: data.eventName,
       index: data.index,
       objectIDs: formatValueToList(data.objectIDs),
+      objectData: transformObjectData(data.objectData),
       userToken: data.userToken,
       value: data.value,
       currency: data.currency,


### PR DESCRIPTION
EEX-780

In GTM a conversion event providing object data:

<img width="936" alt="image" src="https://github.com/algolia/search-insights-gtm/assets/626664/df6116aa-1ec2-4ed2-be21-34de0ebb11f0">

A lone conversion event that can work without providing object data:

<img width="950" alt="image" src="https://github.com/algolia/search-insights-gtm/assets/626664/12f7d1cd-db22-4f3f-add3-b73a181f1503">

Our lone conversion event works:

<img width="695" alt="image" src="https://github.com/algolia/search-insights-gtm/assets/626664/daf19fe6-8079-4862-8ea8-154cb0280aef">

And our event with object data also works. Note that empty fields are cleared out of the payload so that the API is happy:

<img width="695" alt="image" src="https://github.com/algolia/search-insights-gtm/assets/626664/b4eb387d-6a06-4cd4-b83c-121a430eb2c3">
