### PR TITLE
feat: support authenticated user tokens

### DIFF
--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -11,6 +11,10 @@
         "value": "init"
       },
       {
+        "displayValue": "Set Authenticated User Token",
+        "value": "setAuthenticatedUserToken"
+      },
+      {
         "displayValue": "Clicked Object IDs",
         "value": "clickedObjectIDs"
       },
@@ -60,6 +64,18 @@
         ],
         "displayName": "Initializes the Algola Search Insights library.",
         "name": "labelInit",
+        "type": "LABEL"
+      },
+      {
+        "enablingConditions": [
+          {
+            "paramName": "method",
+            "type": "EQUALS",
+            "paramValue": "setAuthenticatedUserToken"
+          }
+        ],
+        "displayName": "Set the authenticated user token for all subsequent events sent to the Algolia Insights API. Use this method to automatically send the `authenticatedUserToken` with every event.",
+        "name": "labelSetAuthenticatedUserToken",
         "type": "LABEL"
       },
       {
@@ -298,8 +314,55 @@
     "enablingConditions": [
       {
         "paramName": "method",
-        "type": "NOT_EQUALS",
-        "paramValue": "init"
+        "type": "EQUALS",
+        "paramValue": "setAuthenticatedUserToken"
+      }
+    ],
+    "name": "SetAuthenticatedUserTokenOptions",
+    "displayName": "Set Authenticated User Options",
+    "groupStyle": "NO_ZIPPY",
+    "type": "GROUP",
+    "subParams": [
+      {
+        "displayName": "Authenticated User Token",
+        "help": "Pseudonymous identifier for authenticated users. Never include personally identifiable information in user tokens.",
+        "name": "setAuthenticatedUserToken_token",
+        "type": "TEXT",
+        "simpleValueType": true
+      }
+    ]
+  },
+  {
+    "enablingConditions": [
+      {
+        "paramName": "method",
+        "type": "EQUALS",
+        "paramValue": "clickedObjectIDs"
+      },
+      {
+        "paramName": "method",
+        "type": "EQUALS",
+        "paramValue": "clickedObjectIDsAfterSearch"
+      },
+      {
+        "paramName": "method",
+        "type": "EQUALS",
+        "paramValue": "clickedFilters"
+      },
+      {
+        "paramName": "method",
+        "type": "EQUALS",
+        "paramValue": "convertedObjectIDs"
+      },
+      {
+        "paramName": "method",
+        "type": "EQUALS",
+        "paramValue": "convertedObjectIDsAfterSearch"
+      },
+      {
+        "paramName": "method",
+        "type": "EQUALS",
+        "paramValue": "convertedFilters"
       }
     ],
     "name": "EventOptions",
@@ -311,6 +374,13 @@
         "displayName": "User Token",
         "name": "userToken",
         "help": "The identifier of the user.",
+        "type": "TEXT",
+        "simpleValueType": true
+      },
+      {
+        "displayName": "Authenticated User Token",
+        "name": "authenticatedUserToken",
+        "help": "Optional. Pseudonymous identifier for authenticated users. Never include personally identifiable information in user tokens.",
         "type": "TEXT",
         "simpleValueType": true
       },

--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -62,7 +62,7 @@
             "paramValue": "init"
           }
         ],
-        "displayName": "Initializes the Algola Search Insights library.",
+        "displayName": "Initializes the Algolia Search Insights library.",
         "name": "labelInit",
         "type": "LABEL"
       },

--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -219,6 +219,13 @@
     "type": "GROUP",
     "subParams": [
       {
+        "displayName": "Authenticated User Token",
+        "name": "init_authenticatedUserToken",
+        "help": "Optional. Pseudonymous identifier for authenticated users. Never include personally identifiable information in user tokens.",
+        "type": "TEXT",
+        "simpleValueType": true
+      },
+      {
         "displayName": "Opt Out User",
         "name": "userHasOptedOut",
         "help": "Whether to exclude users from analytics.",

--- a/src/template.js
+++ b/src/template.js
@@ -173,6 +173,7 @@ switch (data.method) {
     const initOptions = {
       appId: data.appId,
       apiKey: data.apiKey,
+      authenticatedUserToken: data.init_authenticatedUserToken,
       userHasOptedOut: data.userHasOptedOut,
       region: data.region,
       cookieDuration: data.cookieDuration,

--- a/src/template.js
+++ b/src/template.js
@@ -97,7 +97,7 @@ function chunkPayload(payload, keys, limit) {
     .map((k) => payload[k].length)
     .every((n) => n === payload[keys[0]].length);
   if (!sameNumberOfValues) {
-    // chunking behaviour is unsafe due to unequal length arrays to chunk.
+    // chunking behavior is unsafe due to unequal length arrays to chunk.
     // bail out early.
     return [payload];
   }
@@ -137,7 +137,7 @@ switch (data.method) {
 
           let libraryLoaded = false;
           // call any method to see if it reacts.
-          // `getUserToken` is syncronous, so it updates the flag immediately.
+          // `getUserToken` is synchronous, so it updates the flag immediately.
           aa('getUserToken', null, () => {
             libraryLoaded = true;
           });
@@ -196,6 +196,19 @@ switch (data.method) {
     break;
   }
 
+  case 'setAuthenticatedUserToken': {
+    if (!isInitialized()) {
+      logger('You need to call the "init" method first.');
+      data.gtmOnFailure();
+      break;
+    }
+
+    const token = data.setAuthenticatedUserToken_token || undefined;
+
+    logger('setAuthenticatedUserToken', token);
+    aa('setAuthenticatedUserToken', token);
+  }
+
   case 'viewedObjectIDs': {
     if (!isInitialized()) {
       logger('You need to call the "init" event first.');
@@ -210,6 +223,7 @@ switch (data.method) {
       objectIDs: formatValueToList(data.objectIDs),
       objectData: transformObjectData(data.objectData),
       userToken: data.userToken,
+      authenticatedUserToken: data.authenticatedUserToken,
     };
     const chunks = chunkPayload(payload, ['objectIDs'], MAX_OBJECT_IDS);
 
@@ -235,6 +249,7 @@ switch (data.method) {
       positions: formatValueToList(data.positions).map(makeInteger),
       queryID: data.queryID,
       userToken: data.userToken,
+      authenticatedUserToken: data.authenticatedUserToken,
     };
     const chunks = chunkPayload(
       payload,
@@ -263,6 +278,7 @@ switch (data.method) {
       objectIDs: formatValueToList(data.objectIDs),
       objectData: transformObjectData(data.objectData),
       userToken: data.userToken,
+      authenticatedUserToken: data.authenticatedUserToken,
     };
     const chunks = chunkPayload(payload, ['objectIDs'], MAX_OBJECT_IDS);
 
@@ -285,6 +301,7 @@ switch (data.method) {
       filters: formatValueToList(data.filters),
       index: data.index,
       userToken: data.userToken,
+      authenticatedUserToken: data.authenticatedUserToken,
     };
     const chunks = chunkPayload(payload, ['filters'], MAX_FILTERS);
 
@@ -309,6 +326,7 @@ switch (data.method) {
       objectData: transformObjectData(data.objectData),
       queryID: data.queryID,
       userToken: data.userToken,
+      authenticatedUserToken: data.authenticatedUserToken,
       value: data.value,
       currency: data.currency,
     };
@@ -337,6 +355,7 @@ switch (data.method) {
       objectIDs: formatValueToList(data.objectIDs),
       objectData: transformObjectData(data.objectData),
       userToken: data.userToken,
+      authenticatedUserToken: data.authenticatedUserToken,
       value: data.value,
       currency: data.currency,
     };
@@ -364,6 +383,7 @@ switch (data.method) {
       filters: formatValueToList(data.filters),
       index: data.index,
       userToken: data.userToken,
+      authenticatedUserToken: data.authenticatedUserToken,
       value: data.value,
       currency: data.currency,
     };
@@ -391,6 +411,7 @@ switch (data.method) {
       filters: formatValueToList(data.filters),
       index: data.index,
       userToken: data.userToken,
+      authenticatedUserToken: data.authenticatedUserToken,
     };
     const chunks = chunkPayload(payload, ['filters'], MAX_FILTERS);
 


### PR DESCRIPTION
- There is a new method `setAuthenticatedUserToken`. Allows users to set their auth user token once they have it.
- There is a new field on each send event method `authenticatedUserToken`. Allows each send call to override the auth user token if they desire, but otherwise it falls back to the globally set value (if any).
- Need to change the conditions that event options are shown to be any valid send event method rather than `init`, because of the new method `setAuthenticatedUserToken`.

A tag to set the auth user token globally after 10ms trigger:

<img width="957" alt="image" src="https://github.com/algolia/search-insights-gtm/assets/626664/a353e372-aedd-4ff5-bdc3-37d958afaabc">

Events received in the debugger use the global auth user token:

<img width="1562" alt="image" src="https://github.com/algolia/search-insights-gtm/assets/626664/113876a8-b58a-4721-a442-b8a821373b3c">

A tag with an overridden auth user token:

<img width="724" alt="image" src="https://github.com/algolia/search-insights-gtm/assets/626664/68d9a60f-99fb-4b8d-8de9-840ad4dfcd32">

Received by the debugger (and is not the global token but the overridden one):

<img width="1519" alt="image" src="https://github.com/algolia/search-insights-gtm/assets/626664/75500ddb-3e35-4891-9b63-211c952f7572">


EEX-780