### PR TITLE
fix(.github): add missing GHA noop file

### DIFF
--- a/.github/workflows/github_actions_noop.yaml
+++ b/.github/workflows/github_actions_noop.yaml
@@ -1,0 +1,19 @@
+name: '(noop) GitHub Actions'
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  lint:
+    name: 'Lint GitHub Actions'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 2
+    steps:
+      - run: echo "no GitHub Actions changes to lint"


### PR DESCRIPTION
Missed from previous commit. Required so that if you enable required checks for this workflow, it doesn't cause PRs that don't change the .github folder to get stuck.