### PR TITLE
fix: enable objectData to be specified as a simple text field

### DIFF
--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -463,35 +463,20 @@
           {
             "paramName": "method",
             "type": "EQUALS",
-            "paramValue": "clickedObjectIDs"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
-            "paramValue": "clickedObjectIDsAfterSearch"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
             "paramValue": "convertedObjectIDs"
           },
           {
             "paramName": "method",
             "type": "EQUALS",
             "paramValue": "convertedObjectIDsAfterSearch"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
-            "paramValue": "viewedObjectIDs"
           }
         ]
       },
       {
-        "type": "SIMPLE_TABLE",
+        "type": "TEXT",
         "name": "objectData",
         "displayName": "Object Data",
-        "help": "A list of data containing additional information about associated objects (maximum of 20).",
+        "help": "A list of <a href=\"https://www.algolia.com/doc/api-reference/api-methods/added-to-cart-object-ids/#method-param-objectdata-2\">data</a> containing additional information about associated objects (maximum of 20).",
         "enablingConditions": [
           {
             "paramName": "method",
@@ -517,32 +502,6 @@
             "paramName": "method",
             "type": "EQUALS",
             "paramValue": "convertedObjectIDs"
-          }
-        ],
-        "simpleTableColumns": [
-          {
-            "defaultValue": "",
-            "displayName": "Query ID",
-            "name": "queryID",
-            "type": "TEXT"
-          },
-          {
-            "defaultValue": "",
-            "displayName": "Price",
-            "name": "price",
-            "type": "TEXT"
-          },
-          {
-            "defaultValue": "",
-            "displayName": "Discount",
-            "name": "discount",
-            "type": "TEXT"
-          },
-          {
-            "defaultValue": "",
-            "displayName": "Quantity",
-            "name": "quantity",
-            "type": "TEXT"
           }
         ]
       },

--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -463,12 +463,27 @@
           {
             "paramName": "method",
             "type": "EQUALS",
+            "paramValue": "clickedObjectIDs"
+          },
+          {
+            "paramName": "method",
+            "type": "EQUALS",
+            "paramValue": "clickedObjectIDsAfterSearch"
+          },
+          {
+            "paramName": "method",
+            "type": "EQUALS",
             "paramValue": "convertedObjectIDs"
           },
           {
             "paramName": "method",
             "type": "EQUALS",
             "paramValue": "convertedObjectIDsAfterSearch"
+          },
+          {
+            "paramName": "method",
+            "type": "EQUALS",
+            "paramValue": "viewedObjectIDs"
           }
         ]
       },

--- a/src/template-parameters.json
+++ b/src/template-parameters.json
@@ -481,21 +481,6 @@
           {
             "paramName": "method",
             "type": "EQUALS",
-            "paramValue": "viewedObjectIDs"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
-            "paramValue": "clickedObjectIDsAfterSearch"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
-            "paramValue": "clickedObjectIDs"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
             "paramValue": "convertedObjectIDsAfterSearch"
           },
           {

--- a/src/template.js
+++ b/src/template.js
@@ -38,11 +38,13 @@ function formatValueToList(value) {
 
 function transformObjectData(objectData) {
   if (getType(objectData) !== 'array') {
+    logger('objectData is not a list', objectData);
     return objectData;
   }
 
   return objectData.map((od) => {
     if (getType(od) !== 'object') {
+      logger('objectData list item is not an object', od);
       return od;
     }
 

--- a/template.tpl
+++ b/template.tpl
@@ -508,21 +508,6 @@ ___TEMPLATE_PARAMETERS___
           {
             "paramName": "method",
             "type": "EQUALS",
-            "paramValue": "viewedObjectIDs"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
-            "paramValue": "clickedObjectIDsAfterSearch"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
-            "paramValue": "clickedObjectIDs"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
             "paramValue": "convertedObjectIDsAfterSearch"
           },
           {

--- a/template.tpl
+++ b/template.tpl
@@ -490,12 +490,27 @@ ___TEMPLATE_PARAMETERS___
           {
             "paramName": "method",
             "type": "EQUALS",
+            "paramValue": "clickedObjectIDs"
+          },
+          {
+            "paramName": "method",
+            "type": "EQUALS",
+            "paramValue": "clickedObjectIDsAfterSearch"
+          },
+          {
+            "paramName": "method",
+            "type": "EQUALS",
             "paramValue": "convertedObjectIDs"
           },
           {
             "paramName": "method",
             "type": "EQUALS",
             "paramValue": "convertedObjectIDsAfterSearch"
+          },
+          {
+            "paramName": "method",
+            "type": "EQUALS",
+            "paramValue": "viewedObjectIDs"
           }
         ]
       },

--- a/template.tpl
+++ b/template.tpl
@@ -490,35 +490,20 @@ ___TEMPLATE_PARAMETERS___
           {
             "paramName": "method",
             "type": "EQUALS",
-            "paramValue": "clickedObjectIDs"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
-            "paramValue": "clickedObjectIDsAfterSearch"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
             "paramValue": "convertedObjectIDs"
           },
           {
             "paramName": "method",
             "type": "EQUALS",
             "paramValue": "convertedObjectIDsAfterSearch"
-          },
-          {
-            "paramName": "method",
-            "type": "EQUALS",
-            "paramValue": "viewedObjectIDs"
           }
         ]
       },
       {
-        "type": "SIMPLE_TABLE",
+        "type": "TEXT",
         "name": "objectData",
         "displayName": "Object Data",
-        "help": "A list of data containing additional information about associated objects (maximum of 20).",
+        "help": "A list of <a href=\"https://www.algolia.com/doc/api-reference/api-methods/added-to-cart-object-ids/#method-param-objectdata-2\">data</a> containing additional information about associated objects (maximum of 20).",
         "enablingConditions": [
           {
             "paramName": "method",
@@ -544,32 +529,6 @@ ___TEMPLATE_PARAMETERS___
             "paramName": "method",
             "type": "EQUALS",
             "paramValue": "convertedObjectIDs"
-          }
-        ],
-        "simpleTableColumns": [
-          {
-            "defaultValue": "",
-            "displayName": "Query ID",
-            "name": "queryID",
-            "type": "TEXT"
-          },
-          {
-            "defaultValue": "",
-            "displayName": "Price",
-            "name": "price",
-            "type": "TEXT"
-          },
-          {
-            "defaultValue": "",
-            "displayName": "Discount",
-            "name": "discount",
-            "type": "TEXT"
-          },
-          {
-            "defaultValue": "",
-            "displayName": "Quantity",
-            "name": "quantity",
-            "type": "TEXT"
           }
         ]
       },
@@ -914,11 +873,13 @@ function formatValueToList(value) {
 
 function transformObjectData(objectData) {
   if (getType(objectData) !== 'array') {
+    logger('objectData is not a list', objectData);
     return objectData;
   }
 
   return objectData.map((od) => {
     if (getType(od) !== 'object') {
+      logger('objectData list item is not an object', od);
       return od;
     }
 


### PR DESCRIPTION
https://algolia.atlassian.net/browse/EEX-884

The "simple table" method would be pretty much unusable for customers trying to add objectData. Using a text field will allow customers to set the value based on some variable that they specify.

Also, there were a few too many methods that we were allowing to send objectData, where we only really want it for conversions.