### PR TITLE
EEX-1092: don't fail on a second initialisation call

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -12,7 +12,7 @@ const Object = require('Object');
 const TEMPLATE_VERSION = '1.5.2';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
 const INSIGHTS_LIBRARY_URL =
-  'https://cdn.jsdelivr.net/npm/search-insights@2.10.0';
+  'https://cdn.jsdelivr.net/npm/search-insights@2.13.0';
 
 const MAX_OBJECT_IDS = 20;
 const MAX_FILTERS = 10;

--- a/src/template.js
+++ b/src/template.js
@@ -119,9 +119,20 @@ function chunkPayload(payload, keys, limit) {
 
 switch (data.method) {
   case 'init': {
+    const pointer = copyFromWindow(INSIGHTS_OBJECT_NAME);
+    if (pointer && pointer !== 'aa') {
+      logger(
+        'window.' +
+          INSIGHTS_OBJECT_NAME +
+          ' is "' +
+          pointer +
+          '", not "aa". This might cause issues if not using GTM to send events.'
+      );
+    }
+
     if (isInitialized()) {
       logger('The "init" event has already been called.');
-      data.gtmOnFailure();
+      data.gtmOnSuccess();
       break;
     }
 

--- a/template.tpl
+++ b/template.tpl
@@ -954,9 +954,20 @@ function chunkPayload(payload, keys, limit) {
 
 switch (data.method) {
   case 'init': {
+    const pointer = copyFromWindow(INSIGHTS_OBJECT_NAME);
+    if (pointer && pointer !== 'aa') {
+      logger(
+        'window.' +
+          INSIGHTS_OBJECT_NAME +
+          ' is "' +
+          pointer +
+          '", not "aa". This might cause issues if not using GTM to send events.'
+      );
+    }
+
     if (isInitialized()) {
       logger('The "init" event has already been called.');
-      data.gtmOnFailure();
+      data.gtmOnSuccess();
       break;
     }
 

--- a/template.tpl
+++ b/template.tpl
@@ -847,7 +847,7 @@ const Object = require('Object');
 const TEMPLATE_VERSION = '1.5.2';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
 const INSIGHTS_LIBRARY_URL =
-  'https://cdn.jsdelivr.net/npm/search-insights@2.10.0';
+  'https://cdn.jsdelivr.net/npm/search-insights@2.13.0';
 
 const MAX_OBJECT_IDS = 20;
 const MAX_FILTERS = 10;


### PR DESCRIPTION
**Context:**
GTM's insights might get loaded after insights has already been pulled in and intialised by instantsearch (using the `insights: true` flag or by automatic events) which causes an exception.

This doesn't need to be a failure, as it just means there's already an initialised copy of insights which can be used to send events, so a change has been made to still log the message but not to throw an exception.