### PR TITLE
fix: don't log debug statement if objectData is undefined

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -36,9 +36,18 @@ function formatValueToList(value) {
   }
 }
 
+function isNullOrUndefined(value) {
+  const type = getType(value);
+  return type === 'null' || type === 'undefined';
+}
+
 function transformObjectData(objectData) {
   const objectDataType = getType(objectData);
-  if (objectDataType !== 'undefined' && objectDataType !== 'array') {
+  if (isNullOrUndefined(objectDataType)) {
+    return objectData;
+  }
+
+  if (objectDataType !== 'array') {
     logger('objectData is not a list', objectData);
     return objectData;
   }

--- a/src/template.js
+++ b/src/template.js
@@ -37,7 +37,8 @@ function formatValueToList(value) {
 }
 
 function transformObjectData(objectData) {
-  if (getType(objectData) !== 'array') {
+  const objectDataType = getType(objectData);
+  if (objectDataType !== 'undefined' && objectDataType !== 'array') {
     logger('objectData is not a list', objectData);
     return objectData;
   }

--- a/template.tpl
+++ b/template.tpl
@@ -872,7 +872,8 @@ function formatValueToList(value) {
 }
 
 function transformObjectData(objectData) {
-  if (getType(objectData) !== 'array') {
+  const objectDataType = getType(objectData);
+  if (objectDataType !== 'undefined' && objectDataType !== 'array') {
     logger('objectData is not a list', objectData);
     return objectData;
   }

--- a/template.tpl
+++ b/template.tpl
@@ -871,9 +871,18 @@ function formatValueToList(value) {
   }
 }
 
+function isNullOrUndefined(value) {
+  const type = getType(value);
+  return type === 'null' || type === 'undefined';
+}
+
 function transformObjectData(objectData) {
   const objectDataType = getType(objectData);
-  if (objectDataType !== 'undefined' && objectDataType !== 'array') {
+  if (isNullOrUndefined(objectDataType)) {
+    return objectData;
+  }
+
+  if (objectDataType !== 'array') {
     logger('objectData is not a list', objectData);
     return objectData;
   }


### PR DESCRIPTION
If `objectData` isn't passed, don't show the incorrect type debug message.

[CR-5868](https://algolia.atlassian.net/browse/CR-5868)

[CR-5868]: https://algolia.atlassian.net/browse/CR-5868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ