### PR TITLE
fix: never skip init

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -19,8 +19,17 @@ const MAX_FILTERS = 10;
 
 const aa = createArgumentsQueue('aa', 'aa.queue');
 
-function isInitialized() {
+function isInsightsLoaded() {
   return !!copyFromWindow(INSIGHTS_OBJECT_NAME);
+}
+
+function isInitialized() {
+  try {
+    aa('sendEvents', []);
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 function formatValueToList(value) {
@@ -140,52 +149,54 @@ switch (data.method) {
       );
     }
 
+    if (!isInsightsLoaded()) {
+      const url = getLibraryURL(data.useIIFE);
+
+      if (queryPermission('inject_script', url)) {
+        injectScript(
+          url,
+          () => {
+            if (!copyFromWindow('aa')) {
+              data.gtmOnFailure();
+              logger('[ERROR] Failed to load search-insights.');
+              return;
+            }
+
+            let libraryLoaded = false;
+            // call any method to see if it reacts.
+            // `getUserToken` is synchronous, so it updates the flag immediately.
+            aa('getUserToken', null, () => {
+              libraryLoaded = true;
+            });
+            if (libraryLoaded) {
+              data.gtmOnSuccess();
+            } else {
+              log(
+                '[ERROR] Failed to load search-insights.\n\n' +
+                  'If your website is using RequireJS, you need to turn on "Use IIFE" option of Initialization method.'
+              );
+              data.gtmOnFailure();
+            }
+          },
+          data.gtmOnFailure,
+          url
+        );
+      } else {
+        logger(
+          'The library endpoint is not allowed in the "Injects Scripts" permissions.\n\n' +
+            'You need to add the value: "' +
+            'https://cdn.jsdelivr.net/npm/search-insights*' +
+            '"\n\n' +
+            'See https://www.simoahava.com/analytics/custom-templates-guide-for-google-tag-manager/#step-4-modify-permissions'
+        );
+        data.gtmOnFailure();
+        break;
+      }
+    }
+
     if (isInitialized()) {
       logger('The "init" event has already been called.');
       data.gtmOnSuccess();
-      break;
-    }
-
-    const url = getLibraryURL(data.useIIFE);
-
-    if (queryPermission('inject_script', url)) {
-      injectScript(
-        url,
-        () => {
-          if (!copyFromWindow('aa')) {
-            data.gtmOnFailure();
-            logger('[ERROR] Failed to load search-insights.');
-            return;
-          }
-
-          let libraryLoaded = false;
-          // call any method to see if it reacts.
-          // `getUserToken` is synchronous, so it updates the flag immediately.
-          aa('getUserToken', null, () => {
-            libraryLoaded = true;
-          });
-          if (libraryLoaded) {
-            data.gtmOnSuccess();
-          } else {
-            log(
-              '[ERROR] Failed to load search-insights.\n\n' +
-                'If your website is using RequireJS, you need to turn on "Use IIFE" option of Initialization method.'
-            );
-            data.gtmOnFailure();
-          }
-        },
-        data.gtmOnFailure,
-        url
-      );
-    } else {
-      logger(
-        'The library endpoint is not allowed in the "Injects Scripts" permissions.\n\n' +
-          'You need to add the value: "' +
-          'https://cdn.jsdelivr.net/npm/search-insights*' +
-          '"\n\n' +
-          'See https://www.simoahava.com/analytics/custom-templates-guide-for-google-tag-manager/#step-4-modify-permissions'
-      );
-      data.gtmOnFailure();
       break;
     }
 
@@ -221,7 +232,7 @@ switch (data.method) {
   }
 
   case 'setAuthenticatedUserToken': {
-    if (!isInitialized()) {
+    if (!isInsightsLoaded()) {
       logger('You need to call the "init" method first.');
       data.gtmOnFailure();
       break;
@@ -235,7 +246,7 @@ switch (data.method) {
   }
 
   case 'viewedObjectIDs': {
-    if (!isInitialized()) {
+    if (!isInsightsLoaded()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -259,7 +270,7 @@ switch (data.method) {
   }
 
   case 'clickedObjectIDsAfterSearch': {
-    if (!isInitialized()) {
+    if (!isInsightsLoaded()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -289,7 +300,7 @@ switch (data.method) {
   }
 
   case 'clickedObjectIDs': {
-    if (!isInitialized()) {
+    if (!isInsightsLoaded()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -314,7 +325,7 @@ switch (data.method) {
   }
 
   case 'clickedFilters': {
-    if (!isInitialized()) {
+    if (!isInsightsLoaded()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -337,7 +348,7 @@ switch (data.method) {
   }
 
   case 'convertedObjectIDsAfterSearch': {
-    if (!isInitialized()) {
+    if (!isInsightsLoaded()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -367,7 +378,7 @@ switch (data.method) {
   }
 
   case 'convertedObjectIDs': {
-    if (!isInitialized()) {
+    if (!isInsightsLoaded()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -396,7 +407,7 @@ switch (data.method) {
   }
 
   case 'convertedFilters': {
-    if (!isInitialized()) {
+    if (!isInsightsLoaded()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -424,7 +435,7 @@ switch (data.method) {
   }
 
   case 'viewedFilters': {
-    if (!isInitialized()) {
+    if (!isInsightsLoaded()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;

--- a/src/template.js
+++ b/src/template.js
@@ -19,18 +19,8 @@ const MAX_FILTERS = 10;
 
 const aa = createArgumentsQueue('aa', 'aa.queue');
 
-function isInsightsLoaded() {
-  return !!copyFromWindow(INSIGHTS_OBJECT_NAME);
-}
-
 function isInitialized() {
-  try {
-    // sendEvents will throw an error if the apiKey and appId are not set.
-    aa('sendEvents', []);
-    return true;
-  } catch (e) {
-    return false;
-  }
+  return !!copyFromWindow(INSIGHTS_OBJECT_NAME);
 }
 
 function formatValueToList(value) {
@@ -150,7 +140,7 @@ switch (data.method) {
       );
     }
 
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       const url = getLibraryURL(data.useIIFE);
 
       if (queryPermission('inject_script', url)) {
@@ -193,10 +183,8 @@ switch (data.method) {
         data.gtmOnFailure();
         break;
       }
-    } else if (isInitialized()) {
-      logger('The "init" event has already been called.');
-      data.gtmOnSuccess();
-      break;
+    } else {
+      logger('[INFO] search-insights is already loaded.');
     }
 
     log(
@@ -231,7 +219,7 @@ switch (data.method) {
   }
 
   case 'setAuthenticatedUserToken': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" method first.');
       data.gtmOnFailure();
       break;
@@ -245,7 +233,7 @@ switch (data.method) {
   }
 
   case 'viewedObjectIDs': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -269,7 +257,7 @@ switch (data.method) {
   }
 
   case 'clickedObjectIDsAfterSearch': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -299,7 +287,7 @@ switch (data.method) {
   }
 
   case 'clickedObjectIDs': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -324,7 +312,7 @@ switch (data.method) {
   }
 
   case 'clickedFilters': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -347,7 +335,7 @@ switch (data.method) {
   }
 
   case 'convertedObjectIDsAfterSearch': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -377,7 +365,7 @@ switch (data.method) {
   }
 
   case 'convertedObjectIDs': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -406,7 +394,7 @@ switch (data.method) {
   }
 
   case 'convertedFilters': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -434,7 +422,7 @@ switch (data.method) {
   }
 
   case 'viewedFilters': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;

--- a/src/template.js
+++ b/src/template.js
@@ -25,6 +25,7 @@ function isInsightsLoaded() {
 
 function isInitialized() {
   try {
+    // sendEvents will throw an error if the apiKey and appId are not set.
     aa('sendEvents', []);
     return true;
   } catch (e) {
@@ -192,9 +193,7 @@ switch (data.method) {
         data.gtmOnFailure();
         break;
       }
-    }
-
-    if (isInitialized()) {
+    } else if (isInitialized()) {
       logger('The "init" event has already been called.');
       data.gtmOnSuccess();
       break;

--- a/src/template.js
+++ b/src/template.js
@@ -12,7 +12,7 @@ const Object = require('Object');
 const TEMPLATE_VERSION = '1.5.4';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
 const INSIGHTS_LIBRARY_URL =
-  'https://cdn.jsdelivr.net/npm/search-insights@2.13.0';
+  'https://cdn.jsdelivr.net/npm/search-insights@2.14.0';
 
 const MAX_OBJECT_IDS = 20;
 const MAX_FILTERS = 10;

--- a/template.tpl
+++ b/template.tpl
@@ -860,6 +860,7 @@ function isInsightsLoaded() {
 
 function isInitialized() {
   try {
+    // sendEvents will throw an error if the apiKey and appId are not set.
     aa('sendEvents', []);
     return true;
   } catch (e) {
@@ -1027,9 +1028,7 @@ switch (data.method) {
         data.gtmOnFailure();
         break;
       }
-    }
-
-    if (isInitialized()) {
+    } else if (isInitialized()) {
       logger('The "init" event has already been called.');
       data.gtmOnSuccess();
       break;

--- a/template.tpl
+++ b/template.tpl
@@ -854,18 +854,8 @@ const MAX_FILTERS = 10;
 
 const aa = createArgumentsQueue('aa', 'aa.queue');
 
-function isInsightsLoaded() {
-  return !!copyFromWindow(INSIGHTS_OBJECT_NAME);
-}
-
 function isInitialized() {
-  try {
-    // sendEvents will throw an error if the apiKey and appId are not set.
-    aa('sendEvents', []);
-    return true;
-  } catch (e) {
-    return false;
-  }
+  return !!copyFromWindow(INSIGHTS_OBJECT_NAME);
 }
 
 function formatValueToList(value) {
@@ -985,7 +975,7 @@ switch (data.method) {
       );
     }
 
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       const url = getLibraryURL(data.useIIFE);
 
       if (queryPermission('inject_script', url)) {
@@ -1028,10 +1018,8 @@ switch (data.method) {
         data.gtmOnFailure();
         break;
       }
-    } else if (isInitialized()) {
-      logger('The "init" event has already been called.');
-      data.gtmOnSuccess();
-      break;
+    } else {
+      logger('[INFO] search-insights is already loaded.');
     }
 
     log(
@@ -1066,7 +1054,7 @@ switch (data.method) {
   }
 
   case 'setAuthenticatedUserToken': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" method first.');
       data.gtmOnFailure();
       break;
@@ -1080,7 +1068,7 @@ switch (data.method) {
   }
 
   case 'viewedObjectIDs': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -1104,7 +1092,7 @@ switch (data.method) {
   }
 
   case 'clickedObjectIDsAfterSearch': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -1134,7 +1122,7 @@ switch (data.method) {
   }
 
   case 'clickedObjectIDs': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -1159,7 +1147,7 @@ switch (data.method) {
   }
 
   case 'clickedFilters': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -1182,7 +1170,7 @@ switch (data.method) {
   }
 
   case 'convertedObjectIDsAfterSearch': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -1212,7 +1200,7 @@ switch (data.method) {
   }
 
   case 'convertedObjectIDs': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -1241,7 +1229,7 @@ switch (data.method) {
   }
 
   case 'convertedFilters': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;
@@ -1269,7 +1257,7 @@ switch (data.method) {
   }
 
   case 'viewedFilters': {
-    if (!isInsightsLoaded()) {
+    if (!isInitialized()) {
       logger('You need to call the "init" event first.');
       data.gtmOnFailure();
       break;

--- a/template.tpl
+++ b/template.tpl
@@ -847,7 +847,7 @@ const Object = require('Object');
 const TEMPLATE_VERSION = '1.5.4';
 const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
 const INSIGHTS_LIBRARY_URL =
-  'https://cdn.jsdelivr.net/npm/search-insights@2.13.0';
+  'https://cdn.jsdelivr.net/npm/search-insights@2.14.0';
 
 const MAX_OBJECT_IDS = 20;
 const MAX_FILTERS = 10;


### PR DESCRIPTION
Due to [this block](https://github.com/algolia/search-insights.js/blob/main/lib/_sendEvent.ts#L15-L23) if the apiKey and appId aren't set an error is thrown, so we can check for that to see if init has been called on the page already or by the tag.

If this call is successful it will result in a 422 from the Insights API, but I would like to change search-insights.js to not send an empty list of events.