### PR TITLE
feat: allow escaped commas and add tests

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -19,6 +19,7 @@ async function build() {
   const sandboxedJsContent = await fs.readFile(
     path.join(ROOT_DIR, 'template.js')
   );
+  const testContent = await fs.readFile(path.join(ROOT_DIR, 'tests.yaml'));
 
   const templateContent = [
     '___TERMS_OF_SERVICE___',
@@ -31,6 +32,8 @@ async function build() {
     webPermissionsContent,
     '___SANDBOXED_JS_FOR_WEB_TEMPLATE___',
     sandboxedJsContent,
+    '___TESTS___',
+    testContent,
   ].join('\n\n');
 
   await fs.writeFile(DIST_PATH, templateContent);

--- a/src/template.js
+++ b/src/template.js
@@ -16,11 +16,31 @@ const INSIGHTS_LIBRARY_URL =
 
 const MAX_OBJECT_IDS = 20;
 const MAX_FILTERS = 10;
+const COMMA_REPLACEMENT = 'PRESERVED_COMMA_HERE';
 
 const aa = createArgumentsQueue('aa', 'aa.queue');
 
 function isInitialized() {
   return !!copyFromWindow(INSIGHTS_OBJECT_NAME);
+}
+
+function replaceEscapedCommas(str) {
+  while (str.indexOf('\\,') !== -1) {
+    str = str.replace('\\,', COMMA_REPLACEMENT);
+  }
+  return str;
+}
+
+function replacePlaceholderText(str) {
+  while (str.indexOf(COMMA_REPLACEMENT) !== -1) {
+    str = str.replace(COMMA_REPLACEMENT, ',');
+  }
+  return str;
+}
+
+function splitPreservingEscapedCommas(str) {
+  // GTM does not support regexes in custom templates, so we need to use straight text replacements instead
+  return replaceEscapedCommas(str).split(',').map(replacePlaceholderText);
 }
 
 function formatValueToList(value) {
@@ -30,7 +50,7 @@ function formatValueToList(value) {
   } else if (type === 'number') {
     return [value];
   } else if (type === 'string') {
-    return value.split(',');
+    return splitPreservingEscapedCommas(value);
   } else {
     return null;
   }

--- a/src/tests.yaml
+++ b/src/tests.yaml
@@ -1,0 +1,65 @@
+scenarios:
+- name: objectIds handles multiple ids
+  code: |-
+    const copyFromWindow = require('copyFromWindow');
+
+    const mockData = {
+      method: 'clickedObjectIDs',
+      eventName: 'click',
+      index: 'my-index',
+      queryID: 'my-query-id',
+      objectIDs: 'foo,bar,baz',
+      objectData: [],
+      userToken: 'my-user-token',
+      authenticatedUserToken: 'my-authenticated-user-token'
+    };
+
+    runCode(mockData);
+
+    const aa = copyFromWindow('aa');
+
+    assertThat(aa.queue[aa.queue.length-1]).isEqualTo(['sendEvents', [{
+      eventType: 'click',
+      eventName: 'click',
+      index: 'my-index',
+      queryID: 'my-query-id',
+      objectIDs: ['foo','bar','baz'],
+      objectData: [],
+      userToken: 'my-user-token',
+      authenticatedUserToken: 'my-authenticated-user-token'
+    }]]);
+- name: objectIds handles multiple ids that contain commas
+  code: |-
+    const copyFromWindow = require('copyFromWindow');
+
+    const mockData = {
+      method: 'clickedObjectIDs',
+      eventName: 'click',
+      index: 'my-index',
+      queryID: 'my-query-id',
+      objectIDs: 'foo\\,bar,ba\\z,with\\,multiple\\,commas',
+      objectData: [],
+      userToken: 'my-user-token',
+      authenticatedUserToken: 'my-authenticated-user-token'
+    };
+
+    runCode(mockData);
+
+    const aa = copyFromWindow('aa');
+
+    assertThat(aa.queue[aa.queue.length-1]).isEqualTo(['sendEvents', [{
+      eventType: 'click',
+      eventName: 'click',
+      index: 'my-index',
+      queryID: 'my-query-id',
+      objectIDs: ['foo,bar','ba\\z', 'with,multiple,commas'],
+      objectData: [],
+      userToken: 'my-user-token',
+      authenticatedUserToken: 'my-authenticated-user-token'
+    }]]);
+setup: |-
+  const setInWindow = require('setInWindow');
+
+  const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
+
+  setInWindow(INSIGHTS_OBJECT_NAME, 'aa'); // isInitialized() will return true

--- a/template.tpl
+++ b/template.tpl
@@ -851,11 +851,31 @@ const INSIGHTS_LIBRARY_URL =
 
 const MAX_OBJECT_IDS = 20;
 const MAX_FILTERS = 10;
+const COMMA_REPLACEMENT = 'PRESERVED_COMMA_HERE';
 
 const aa = createArgumentsQueue('aa', 'aa.queue');
 
 function isInitialized() {
   return !!copyFromWindow(INSIGHTS_OBJECT_NAME);
+}
+
+function replaceEscapedCommas(str) {
+  while (str.indexOf('\\,') !== -1) {
+    str = str.replace('\\,', COMMA_REPLACEMENT);
+  }
+  return str;
+}
+
+function replacePlaceholderText(str) {
+  while (str.indexOf(COMMA_REPLACEMENT) !== -1) {
+    str = str.replace(COMMA_REPLACEMENT, ',');
+  }
+  return str;
+}
+
+function splitPreservingEscapedCommas(str) {
+  // GTM does not support regexes in custom templates, so we need to use straight text replacements instead
+  return replaceEscapedCommas(str).split(',').map(replacePlaceholderText);
 }
 
 function formatValueToList(value) {
@@ -865,7 +885,7 @@ function formatValueToList(value) {
   } else if (type === 'number') {
     return [value];
   } else if (type === 'string') {
-    return value.split(',');
+    return splitPreservingEscapedCommas(value);
   } else {
     return null;
   }
@@ -1284,3 +1304,72 @@ switch (data.method) {
     data.gtmOnFailure();
   }
 }
+
+
+___TESTS___
+
+scenarios:
+- name: objectIds handles multiple ids
+  code: |-
+    const copyFromWindow = require('copyFromWindow');
+
+    const mockData = {
+      method: 'clickedObjectIDs',
+      eventName: 'click',
+      index: 'my-index',
+      queryID: 'my-query-id',
+      objectIDs: 'foo,bar,baz',
+      objectData: [],
+      userToken: 'my-user-token',
+      authenticatedUserToken: 'my-authenticated-user-token'
+    };
+
+    runCode(mockData);
+
+    const aa = copyFromWindow('aa');
+
+    assertThat(aa.queue[aa.queue.length-1]).isEqualTo(['sendEvents', [{
+      eventType: 'click',
+      eventName: 'click',
+      index: 'my-index',
+      queryID: 'my-query-id',
+      objectIDs: ['foo','bar','baz'],
+      objectData: [],
+      userToken: 'my-user-token',
+      authenticatedUserToken: 'my-authenticated-user-token'
+    }]]);
+- name: objectIds handles multiple ids that contain commas
+  code: |-
+    const copyFromWindow = require('copyFromWindow');
+
+    const mockData = {
+      method: 'clickedObjectIDs',
+      eventName: 'click',
+      index: 'my-index',
+      queryID: 'my-query-id',
+      objectIDs: 'foo\\,bar,ba\\z,with\\,multiple\\,commas',
+      objectData: [],
+      userToken: 'my-user-token',
+      authenticatedUserToken: 'my-authenticated-user-token'
+    };
+
+    runCode(mockData);
+
+    const aa = copyFromWindow('aa');
+
+    assertThat(aa.queue[aa.queue.length-1]).isEqualTo(['sendEvents', [{
+      eventType: 'click',
+      eventName: 'click',
+      index: 'my-index',
+      queryID: 'my-query-id',
+      objectIDs: ['foo,bar','ba\\z', 'with,multiple,commas'],
+      objectData: [],
+      userToken: 'my-user-token',
+      authenticatedUserToken: 'my-authenticated-user-token'
+    }]]);
+setup: |-
+  const setInWindow = require('setInWindow');
+
+  const INSIGHTS_OBJECT_NAME = 'AlgoliaAnalyticsObject';
+
+  setInWindow(INSIGHTS_OBJECT_NAME, 'aa'); // isInitialized() will return true


### PR DESCRIPTION
I was going to use a negative lookbehind regex which would have made the replacement much more straightforward, however it seems that GTM doesn't support regex within its sandbox.

EEX-1189