### PR TITLE
feat: convert to TS and enable versioning directly via package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Each section of the custom template is in the [`src/`](src) folder. This command
 
 ### Releasing
 
-The `TEMPLATE_VERSION` variable in the [sandboxed JavaScript](src/template.js) should be incremented for each change. This variable is used to send usage metrics to Algolia.
+The `version` property in [`package.json`](package.json) should be incremented for each change (e.g. run the `yarn version <major|minor|patch>` command). This value is used to send usage metrics to Algolia.
 
 To release a new version:
 

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "search-insights-gtm",
   "description": "Library for detecting front-end Algolia search metrics",
   "private": true,
+  "version": "1.6.6",
   "main": "template.tpl",
   "repository": "algolia/search-insights-gtm",
   "author": "Algolia <support@algolia.com>",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "node scripts/build.js",
+    "build": "yarn tsc && yarn prettier build -w && node scripts/build.js && rimraf build",
     "release": "node scripts/release.js",
     "dev": "nodemon scripts/build.js",
     "start": "yarn run dev"
@@ -16,7 +17,11 @@
     "@types/fs-extra": "^11.0.4",
     "fs-extra": "^11.2.0",
     "nodemon": "^3.1.0",
+    "prettier": "3.3.3",
+    "rimraf": "^6.0.1",
+    "search-insights": "2.14.0",
     "shelljs": "^0.8.5",
+    "typescript": "^5.6.3",
     "yaml": "^2.4.1"
   },
   "packageManager": "yarn@4.1.1"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,8 +1,22 @@
 const fs = require('fs-extra');
 const path = require('path');
-const { main: mainPath } = require('../package.json');
+const { devDependencies, main: mainPath, version } = require('../package.json');
+
+function escapeRegex(string) {
+  return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+function getTemplateStringRegex(value) {
+  return new RegExp(
+    '`([^\\$`]*)(\\$\\{' + escapeRegex(value) + '\\})([^`]*)`',
+    'g'
+  );
+}
+function getTemplateStringReplacement(replacement) {
+  return `'$1${replacement}$3'`;
+}
 
 const ROOT_DIR = path.resolve('src');
+const BUILD_DIR = path.resolve('build');
 const DIST_PATH = path.resolve(mainPath);
 
 async function build() {
@@ -17,9 +31,23 @@ async function build() {
     path.join(ROOT_DIR, 'web-permissions.json')
   );
   const sandboxedJsContent = await fs.readFile(
-    path.join(ROOT_DIR, 'template.js')
+    path.join(BUILD_DIR, 'src', 'template.js')
   );
   const testContent = await fs.readFile(path.join(ROOT_DIR, 'tests.yaml'));
+
+  const replacedJsContent = String(sandboxedJsContent)
+    .replace(
+      "import { devDependencies, version } from '../package.json';\n",
+      ''
+    )
+    .replace(
+      getTemplateStringRegex("devDependencies['search-insights']"),
+      getTemplateStringReplacement(devDependencies['search-insights'])
+    )
+    .replace(
+      getTemplateStringRegex('version'),
+      getTemplateStringReplacement(version)
+    );
 
   const templateContent = [
     '___TERMS_OF_SERVICE___',
@@ -31,7 +59,7 @@ async function build() {
     '___WEB_PERMISSIONS___',
     webPermissionsContent,
     '___SANDBOXED_JS_FOR_WEB_TEMPLATE___',
-    sandboxedJsContent,
+    replacedJsContent,
     '___TESTS___',
     testContent,
   ].join('\n\n');

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,134 @@
+interface GtmWithMethod {
+  method:
+    | 'init'
+    | 'setAuthenticatedUserToken'
+    | 'viewedObjectIDs'
+    | 'clickedObjectIDsAfterSearch'
+    | 'clickedObjectIDs'
+    | 'clickedFilters'
+    | 'convertedObjectIDsAfterSearch'
+    | 'convertedObjectIDs'
+    | 'convertedFilters'
+    | 'viewedFilters';
+  gtmOnSuccess: () => void;
+  gtmOnFailure: () => void;
+}
+
+interface GtmDataInit extends GtmWithMethod {
+  method: 'init';
+  appId: string;
+  apiKey: string;
+  init_authenticatedUserToken: string;
+  userHasOptedOut: boolean;
+  region: 'de' | 'us';
+  cookieDuration: number;
+  useCookie: boolean;
+  host: string;
+  useIIFE: boolean;
+  initialUserToken: string;
+}
+interface GtmDataSetAuthenticatedUserToken extends GtmWithMethod {
+  method: 'setAuthenticatedUserToken';
+  setAuthenticatedUserToken_token: string;
+}
+interface GtmDataEvent extends GtmWithMethod {
+  eventName: string;
+  userToken: string;
+  authenticatedUserToken: string;
+}
+interface GtmDataEventWithObjects extends GtmDataEvent {
+  objectIDs: string[];
+  objectData?: Array<Record<string, string | number | undefined>>;
+}
+interface GtmDataEventWithFilters extends GtmDataEvent {
+  filters: string[];
+}
+interface GtmDataViewedObjectIDs extends GtmDataEventWithObjects {
+  method: 'viewedObjectIDs';
+  index: string;
+}
+interface GtmDataClickedObjectIDsAfterSearch extends GtmDataEventWithObjects {
+  method: 'clickedObjectIDsAfterSearch';
+  index: string;
+  positions: number[];
+  queryID: string;
+}
+interface GtmDataClickedObjectIDs extends GtmDataEventWithObjects {
+  method: 'clickedObjectIDs';
+  index: string;
+  queryID?: string;
+}
+interface GtmDataClickedFilters extends GtmDataEventWithFilters {
+  method: 'clickedFilters';
+  index: string;
+}
+interface GtmDataConvertedObjectIDsAfterSearch extends GtmDataEventWithObjects {
+  method: 'convertedObjectIDsAfterSearch';
+  index: string;
+  queryID: string;
+  eventSubtype: GtmEventSubtype;
+  currency?: string;
+  value?: number | string;
+}
+interface GtmDataConvertedObjectIDs extends GtmDataEventWithObjects {
+  method: 'convertedObjectIDs';
+  index: string;
+  eventSubtype: GtmEventSubtype;
+  currency?: string;
+  value?: number | string;
+}
+interface GtmDataConvertedFilters extends GtmDataEventWithFilters {
+  method: 'convertedFilters';
+  index: string;
+  eventSubtype: GtmEventSubtype;
+  currency?: string;
+  value?: number | string;
+}
+interface GtmDataViewedFilters extends GtmDataEventWithFilters {
+  method: 'viewedFilters';
+  index: string;
+}
+type GtmData =
+  | GtmDataInit
+  | GtmDataSetAuthenticatedUserToken
+  | GtmDataViewedObjectIDs
+  | GtmDataClickedObjectIDsAfterSearch
+  | GtmDataClickedObjectIDs
+  | GtmDataClickedFilters
+  | GtmDataConvertedObjectIDsAfterSearch
+  | GtmDataConvertedObjectIDs
+  | GtmDataConvertedFilters
+  | GtmDataViewedFilters;
+
+declare const data: GtmData;
+
+type GtmEventSubtype = 'addToCart' | 'purchase' | '';
+
+// Tag Manager Template Core APIs
+
+type GtmGetType = (
+  value: any
+) =>
+  | 'null'
+  | 'undefined'
+  | 'boolean'
+  | 'number'
+  | 'string'
+  | 'array'
+  | 'object'
+  | 'function';
+
+type GtmMakeInteger = (value: any) => number;
+
+type GtmMath = Pick<
+  Math,
+  'abs' | 'floor' | 'ceil' | 'round' | 'max' | 'min' | 'pow' | 'sqrt'
+>;
+
+interface GtmObject {
+  delete: (obj: Record<string, any>, key: string) => void;
+  entries: (obj: Record<string, any>) => [string, any][];
+  freeze: (obj: Record<string, any>) => Record<string, any>;
+  keys: (obj: Record<string, any>) => string[];
+  values: (obj: Record<string, any>) => any[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "Preserve",
+    "outDir": "./build",
+    "strict": true,
+    "esModuleInterop": false,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,6 +437,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "glob@npm:11.0.0"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^4.0.1"
+    minimatch: "npm:^10.0.0"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^2.0.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/419866015d8795258a8ac51de5b9d1a99c72634fc3ead93338e4da388e89773ab21681e494eac0fbc4250b003451ca3110bb4f1c9393d15d14466270094fdb4e
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.0.0":
   version: 7.1.6
   resolution: "glob@npm:7.1.6"
@@ -636,6 +652,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "jackspeak@npm:4.0.2"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+  checksum: 10c0/b26039d11c0163a95b1e58851b9ac453cce64ad6d1eb98a00b303ad5eeb761b29d33c9419d1e16c016d3f7151c8edf7df223e6cf93a1907655fd95d6ce85c0de
+  languageName: node
+  linkType: hard
+
 "jsbn@npm:1.1.0":
   version: 1.1.0
   resolution: "jsbn@npm:1.1.0"
@@ -660,6 +685,13 @@ __metadata:
   version: 10.2.0
   resolution: "lru-cache@npm:10.2.0"
   checksum: 10c0/c9847612aa2daaef102d30542a8d6d9b2c2bb36581c1bf0dc3ebf5e5f3352c772a749e604afae2e46873b930a9e9523743faac4e5b937c576ab29196774712ee
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^11.0.0":
+  version: 11.0.2
+  resolution: "lru-cache@npm:11.0.2"
+  checksum: 10c0/c993b8e06ead0b24b969c1dbb5b301716aed66e320e9014a80012f5febe280b438f28ff50046b2c55ff404e889351ccb332ff91f8dd175a21f5eae80e3fb155f
   languageName: node
   linkType: hard
 
@@ -688,6 +720,15 @@ __metadata:
     promise-retry: "npm:^2.0.1"
     ssri: "npm:^10.0.0"
   checksum: 10c0/43b9f6dcbc6fe8b8604cb6396957c3698857a15ba4dbc38284f7f0e61f248300585ef1eb8cc62df54e9c724af977e45b5cdfd88320ef7f53e45070ed3488da55
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "minimatch@npm:10.0.1"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/e6c29a81fe83e1877ad51348306be2e8aeca18c88fdee7a99df44322314279e15799e41d7cb274e4e8bb0b451a3bc622d6182e157dfa1717d6cda75e9cd8cd5d
   languageName: node
   linkType: hard
 
@@ -780,6 +821,13 @@ __metadata:
   version: 7.0.4
   resolution: "minipass@npm:7.0.4"
   checksum: 10c0/6c7370a6dfd257bf18222da581ba89a5eaedca10e158781232a8b5542a90547540b4b9b7e7f490e4cda43acfbd12e086f0453728ecf8c19e0ef6921bc5958ac5
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "minipass@npm:7.1.2"
+  checksum: 10c0/b0fd20bb9fb56e5fa9a8bfac539e8915ae07430a619e4b86ff71f5fc757ef3924b23b2c4230393af1eda647ed3d75739e4e0acb250a6b1eb277cf7f8fe449557
   languageName: node
   linkType: hard
 
@@ -903,6 +951,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "package-json-from-dist@npm:1.0.1"
+  checksum: 10c0/62ba2785eb655fec084a257af34dbe24292ab74516d6aecef97ef72d4897310bc6898f6c85b5cd22770eaa1ce60d55a0230e150fb6a966e3ecd6c511e23d164b
+  languageName: node
+  linkType: hard
+
 "path-is-absolute@npm:^1.0.0":
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
@@ -934,10 +989,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/3da4adedaa8e7ef8d6dc4f35a0ff8f05a9b4d8365f2b28047752b62d4c1ad73eec21e37b1579ef2d075920157856a3b52ae8309c480a6f1a8bbe06ff8e52b33c
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  languageName: node
+  linkType: hard
+
+"prettier@npm:3.3.3":
+  version: 3.3.3
+  resolution: "prettier@npm:3.3.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/b85828b08e7505716324e4245549b9205c0cacb25342a030ba8885aba2039a115dbcf75a0b7ca3b37bc9d101ee61fab8113fc69ca3359f2a226f1ecc07ad2e26
   languageName: node
   linkType: hard
 
@@ -1008,6 +1082,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rimraf@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "rimraf@npm:6.0.1"
+  dependencies:
+    glob: "npm:^11.0.0"
+    package-json-from-dist: "npm:^1.0.0"
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: 10c0/b30b6b072771f0d1e73b4ca5f37bb2944ee09375be9db5f558fcd3310000d29dfcfa93cf7734d75295ad5a7486dc8e40f63089ced1722a664539ffc0c3ece8c6
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -1022,10 +1108,21 @@ __metadata:
     "@types/fs-extra": "npm:^11.0.4"
     fs-extra: "npm:^11.2.0"
     nodemon: "npm:^3.1.0"
+    prettier: "npm:3.3.3"
+    rimraf: "npm:^6.0.1"
+    search-insights: "npm:2.14.0"
     shelljs: "npm:^0.8.5"
+    typescript: "npm:^5.6.3"
     yaml: "npm:^2.4.1"
   languageName: unknown
   linkType: soft
+
+"search-insights@npm:2.14.0":
+  version: 2.14.0
+  resolution: "search-insights@npm:2.14.0"
+  checksum: 10c0/2b404fa30fbd962e1e4831c595801aa97cac3b00047f2f351f7c3baa7b5d701f0c22f61d3e0de12037273fc8b52abf543a9e82a91303c1a5fa5c05395ceece1a
+  languageName: node
+  linkType: hard
 
 "semver@npm:^7.3.5, semver@npm:^7.5.3":
   version: 7.6.0
@@ -1207,6 +1304,26 @@ __metadata:
   bin:
     nodetouch: ./bin/nodetouch.js
   checksum: 10c0/dacb4a639401b83b0a40b56c0565e01096e5ecf38b22a4840d9eeb642a5bea136c6a119e4543f9b172349a5ee343b10cda0880eb47f7d7ddfd6eac59dcf53244
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^5.6.3":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.6.3#optional!builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=5adc0c"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/ac8307bb06bbfd08ae7137da740769b7d8c3ee5943188743bb622c621f8ad61d244767480f90fbd840277fbf152d8932aa20c33f867dea1bb5e79b187ca1a92f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Converted to TypeScript so we can leverage type checking and Intellisense when making any changes to this template. The conversion to TS uncovered a few small bugs which would have resulted in events being rejected as invalid, which have now been resolved.

Enabled bumping versions directly in package.json and replacing those values in the generated template.tpl so that we can more easily automate releasing new versions of this template any time that search-insights.js is released.