### PR TITLE
chore: update metadata.yaml update script to be compatible with Ship.js

### DIFF
--- a/scripts/update-metadata.js
+++ b/scripts/update-metadata.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const { exec } = require('shelljs');
+const YAML = require('yaml');
+
+function getLatestCommit() {
+  const title = exec(`git log -1 --pretty=%s`).toString().trim();
+  const hash = exec(`git log -1 --pretty=%H`).toString().trim();
+  return { title, hash };
+}
+
+function updateMetadata({ tag, hash }) {
+  const filePath = path.resolve('metadata.yaml');
+  const yaml = YAML.parse(fs.readFileSync(filePath).toString());
+  yaml.versions = [
+    {
+      sha: hash,
+      changeNotes: `chore: update version to ${tag}`,
+    },
+    ...yaml.versions,
+  ];
+  fs.writeFileSync(filePath, YAML.stringify(yaml));
+}
+
+function main(tag) {
+  const { hash } = getLatestCommit();
+  updateMetadata({ tag, hash });
+}
+
+main(process.argv[2]);

--- a/ship.config.js
+++ b/ship.config.js
@@ -1,18 +1,4 @@
-const fs = require('fs');
-const path = require('path');
 const { exec } = require('shelljs');
-const YAML = require('yaml');
-
-function getLatestCommit() {
-  const title = exec(`git log -1 --pretty=%s`).toString().trim();
-  const hash = exec(`git log -1 --pretty=%H`).toString().trim();
-  return { title, hash };
-}
-
-function commitMetadata() {
-  exec(`git add metadata.yaml`);
-  exec(`git commit -m "chore: update metadata.yml"`);
-}
 
 module.exports = {
   shouldPrepare: ({ releaseType, commitNumbersPerType }) => {
@@ -24,19 +10,11 @@ module.exports = {
   },
   buildCommand: () => 'yarn build',
   pullRequestTeamReviewers: ['events-platform'],
-  publishCommand: ({ tag, dir }) => {
-    // update metadata.yaml
-    const { hash } = getLatestCommit();
-    const metadataPath = path.resolve(dir, 'metadata.yaml');
-    const yaml = YAML.parse(fs.readFileSync(metadataPath).toString());
-    yaml.versions = [
-      {
-        sha: hash,
-        changeNotes: `chore: update version to ${tag}`,
-      },
-      ...yaml.versions,
-    ];
-    fs.writeFileSync(metadataPath, YAML.stringify(yaml));
-    commitMetadata();
+  publishCommand: ({ tag }) => {
+    // update metadata.yaml by executing external script instead of inline because
+    // the esm module loader being used by Ship.js is incompatible with the YAML package
+    exec(`node scripts/update-metadata.js ${tag}`);
+    exec(`git add metadata.yaml`);
+    exec(`git commit -m "chore: update metadata.yml"`);
   },
 };


### PR DESCRIPTION
I discovered that Ship.js runs inside an ancient, no longer updated, library called [esm](https://github.com/standard-things/esm). The YAML library uses some modern features in it, especially the optional chaining operator (`?.`) which the [esm library is incompatible with](https://github.com/standard-things/esm/issues/866), and as such we need to execute it out of band until Ship.js stops using that library (it's not necessary any more as ESM support is in Node itself, but it's not a trivial update to modernise Ship.js to not require that — I started down that route… not fun).